### PR TITLE
feat: build for Windows as well

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -39,16 +39,24 @@ PLATFORM_LIST = \
         darwin-amd64 \
         darwin-arm64 \
         linux-amd64 \
-        linux-arm64
+        linux-arm64 \
+        windows-amd64
 darwin-%:
 	GOARCH=$* GOOS=darwin $(GOBUILD) -o $(NAME)_$(VERSION)_$@/$(NAME) ./cmd/client
 
 linux-%:
 	GOARCH=$* GOOS=linux $(GOBUILD) -o $(NAME)_$(VERSION)_$@/$(NAME) ./cmd/client
 
+windows-%:
+	GOARCH=$* GOOS=windows $(GOBUILD) -o $(NAME)_$(VERSION)_$@/$(NAME).exe ./cmd/client
+
 gz_releases=$(addsuffix .tar.gz, $(PLATFORM_LIST))
 $(gz_releases): %.tar.gz : %
-	tar czf $(NAME)_$(VERSION)_$@ -C $(NAME)_$(VERSION)_$</ ../LICENSE $(NAME)
+	case $@ in windows-*) \
+	  tar czf $(NAME)_$(VERSION)_$@ -C $(NAME)_$(VERSION)_$</ ../LICENSE $(NAME).exe ;; \
+	*) \
+	  tar czf $(NAME)_$(VERSION)_$@ -C $(NAME)_$(VERSION)_$</ ../LICENSE $(NAME) ;; \
+	esac
 	sha256sum $(NAME)_$(VERSION)_$@ > $(NAME)_$(VERSION)_$@.sha256
 
 .PHONY: releases


### PR DESCRIPTION
This attempts to add Windows (client) to the build - to fix #16.

The changes are:
* Adding `windows-latest` to the os-matrix in `build-and-release.yml`
* Adding `windows-amd64` to the `PLATFORM_LIST` in the `Makefile`
* Adding a `windows-%` build step in the Makefile which creates a `kubectl-relay.exe`-file
* Adjusting the tar command with a `case` statement to use `kubectl-relay.exe` for Windows and `kubectl-relay` for the other platforms

Apologies for any errors. It's only partially possible to check the correct working as I had to make other changes for a test (like publishing to my fork instead of yours), and I also did not test the steps for publishing to `krew`.
So there is some risk it won't work correctly without some fixes.