### PR TITLE
Add TopologySpreadConstraints to server pod

### DIFF
--- a/cmd/client/utils.go
+++ b/cmd/client/utils.go
@@ -48,6 +48,18 @@ func ensureServerPod(ctx context.Context, cs kubernetes.Interface, svrImg, names
 					ImagePullPolicy: corev1.PullAlways,
 				},
 			},
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+				{
+					MaxSkew:           1,
+					TopologyKey:       "kubernetes.io/hostname",
+					WhenUnsatisfiable: "ScheduleAnyway",
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": constants.ServerName,
+						},
+					},
+				},
+			},
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {


### PR DESCRIPTION
Partially related to issue #24, we've exhausted the IPs in a single EC2 instance because all krelay servers where deployed to the same k8s node. We already setup a "krelay killer", but this could happen again if devs starts krelay servers without killing them in a short interval. Maybe a [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) would make this problem a rare occurrence?