### PR TITLE
feat: forward traffic to multiple target

### DIFF
--- a/cmd/client/forwarder.go
+++ b/cmd/client/forwarder.go
@@ -44,8 +44,10 @@ func (p *portForwarder) listen(localIP string) error {
 			return err
 		}
 		p.udpListener = pc
+	default:
+		return fmt.Errorf("unknown protocol: %s", p.ports.Protocol)
 	}
-	return fmt.Errorf("unknown protocol: %s", p.ports.Protocol)
+	return nil
 }
 
 func (p *portForwarder) run(streamConn httpstream.Connection) {

--- a/cmd/client/forwarder.go
+++ b/cmd/client/forwarder.go
@@ -15,47 +15,43 @@ import (
 )
 
 type portForwarder struct {
-	localAddr  string
 	addrGetter remoteaddr.Getter
 	ports      ports.PortPair
 
-	listener   net.Listener
-	packetConn net.PacketConn
+	tcpListener net.Listener
+	udpListener net.PacketConn
 }
 
-func newPortForwarder(addr string, addrGetter remoteaddr.Getter, pp ports.PortPair) *portForwarder {
+func newPortForwarder(addrGetter remoteaddr.Getter, pp ports.PortPair) *portForwarder {
 	return &portForwarder{
-		localAddr:  addr,
 		addrGetter: addrGetter,
 		ports:      pp,
 	}
 }
 
-func (p *portForwarder) listen() error {
-	bindAddr := net.JoinHostPort(p.localAddr, strconv.Itoa(int(p.ports.LocalPort)))
+func (p *portForwarder) listen(localIP string) error {
+	bindAddr := net.JoinHostPort(localIP, strconv.Itoa(int(p.ports.LocalPort)))
 	switch p.ports.Protocol {
 	case constants.ProtocolTCP:
 		l, err := net.Listen(constants.ProtocolTCP, bindAddr)
 		if err != nil {
 			return err
 		}
-		p.listener = l
+		p.tcpListener = l
 	case constants.ProtocolUDP:
 		pc, err := net.ListenPacket(constants.ProtocolUDP, bindAddr)
 		if err != nil {
 			return err
 		}
-		p.packetConn = pc
-	default:
-		return fmt.Errorf("unknown protocol: %s", p.ports.Protocol)
+		p.udpListener = pc
 	}
-	return nil
+	return fmt.Errorf("unknown protocol: %s", p.ports.Protocol)
 }
 
 func (p *portForwarder) run(streamConn httpstream.Connection) {
 	switch {
-	case p.listener != nil:
-		l := p.listener
+	case p.tcpListener != nil:
+		l := p.tcpListener
 		defer l.Close()
 
 		localAddr := l.Addr().String()
@@ -92,8 +88,8 @@ func (p *portForwarder) run(streamConn httpstream.Connection) {
 			go handleTCPConn(c, streamConn, remoteAddr, p.ports.RemotePort)
 		}
 
-	case p.packetConn != nil:
-		pc := p.packetConn
+	case p.udpListener != nil:
+		pc := p.udpListener
 		defer pc.Close()
 
 		udpConn := &xnet.UDPConn{UDPConn: pc.(*net.UDPConn)}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -169,8 +169,8 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 
 	succeeded := false
 	for _, pp := range forwardPorts {
-		pf := newPortForwarder(o.address, addrGetter, pp)
-		err := pf.listen()
+		pf := newPortForwarder(addrGetter, pp)
+		err := pf.listen(o.address)
 		if err != nil {
 			klog.ErrorS(err, "Fail to listen on port", "port", pp.LocalPort)
 		} else {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -125,14 +125,17 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 		default:
 			obj, err := resource.NewBuilder(o.getter).
 				WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
-				NamespaceParam(ns).DefaultNamespace().
+				NamespaceParam(targetSpec.namespace).DefaultNamespace().
 				ResourceNames("pods", targetSpec.resource).
 				Do().Object()
 			if err != nil {
 				return err
 			}
 
-			addrGetter, err = addrGetterForObject(obj, cs, ns)
+			addrGetter, err = addrGetterForObject(obj, cs, targetSpec.namespace)
+			if err != nil {
+				return err
+			}
 			parser = parser.WithObject(obj)
 		}
 

--- a/cmd/client/utils.go
+++ b/cmd/client/utils.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/knight42/krelay/pkg/constants"
+	"github.com/knight42/krelay/pkg/remoteaddr"
 	"github.com/knight42/krelay/pkg/xnet"
 )
 
@@ -124,46 +125,65 @@ func removeServerPod(cs kubernetes.Interface, namespace, podName string, timeout
 	}
 }
 
-func getAddrForObject(obj runtime.Object) (addr xnet.Addr, err error) {
+func addrGetterForObject(obj runtime.Object, cs kubernetes.Interface, ns string) (remoteaddr.Getter, error) {
 	switch actual := obj.(type) {
 	case *corev1.Pod:
-		return xnet.AddrFromIP(actual.Status.PodIP)
+		addr, err := xnet.AddrFromIP(actual.Status.PodIP)
+		if err != nil {
+			return nil, err
+		}
+		return remoteaddr.NewStaticAddr(addr), nil
 
 	case *corev1.Service:
 		if actual.Spec.Type == corev1.ServiceTypeExternalName {
-			return xnet.AddrFromHost(actual.Spec.ExternalName), nil
+			addr := xnet.AddrFromHost(actual.Spec.ExternalName)
+			return remoteaddr.NewStaticAddr(addr), nil
 		}
 		if actual.Spec.ClusterIP != corev1.ClusterIPNone {
-			return xnet.AddrFromIP(actual.Spec.ClusterIP)
+			addr, err := xnet.AddrFromIP(actual.Spec.ClusterIP)
+			if err != nil {
+				return nil, err
+			}
+			return remoteaddr.NewStaticAddr(addr), nil
 		}
 
 		if len(actual.Spec.Selector) == 0 {
-			return addr, fmt.Errorf("service selector is empty")
+			return nil, fmt.Errorf("service selector is empty")
 		}
-	}
 
-	return xnet.Addr{}, nil
-}
-
-func selectorForObject(obj runtime.Object) (labels.Selector, error) {
-	switch actual := obj.(type) {
-	case *corev1.Service:
-		return labels.SelectorFromSet(actual.Spec.Selector), nil
+		selector := labels.SelectorFromSet(actual.Spec.Selector)
+		return remoteaddr.NewDynamicAddr(cs, ns, selector.String())
 
 	case *appsv1.ReplicaSet:
-		return metav1.LabelSelectorAsSelector(actual.Spec.Selector)
+		selector, err := metav1.LabelSelectorAsSelector(actual.Spec.Selector)
+		if err != nil {
+			return nil, err
+		}
+		return remoteaddr.NewDynamicAddr(cs, ns, selector.String())
 
 	case *appsv1.Deployment:
-		return metav1.LabelSelectorAsSelector(actual.Spec.Selector)
+		selector, err := metav1.LabelSelectorAsSelector(actual.Spec.Selector)
+		if err != nil {
+			return nil, err
+		}
+		return remoteaddr.NewDynamicAddr(cs, ns, selector.String())
 
 	case *appsv1.StatefulSet:
-		return metav1.LabelSelectorAsSelector(actual.Spec.Selector)
+		selector, err := metav1.LabelSelectorAsSelector(actual.Spec.Selector)
+		if err != nil {
+			return nil, err
+		}
+		return remoteaddr.NewDynamicAddr(cs, ns, selector.String())
 
 	case *appsv1.DaemonSet:
-		return metav1.LabelSelectorAsSelector(actual.Spec.Selector)
-	default:
-		return nil, fmt.Errorf("selector for %T not implemented", obj)
+		selector, err := metav1.LabelSelectorAsSelector(actual.Spec.Selector)
+		if err != nil {
+			return nil, err
+		}
+		return remoteaddr.NewDynamicAddr(cs, ns, selector.String())
 	}
+
+	return nil, fmt.Errorf("unknown object: %T", obj)
 }
 
 func createStream(c httpstream.Connection, reqID string) (dataStream httpstream.Stream, errCh chan error, err error) {
@@ -208,9 +228,35 @@ func createStream(c httpstream.Connection, reqID string) (dataStream httpstream.
 	return dataStream, errCh, nil
 }
 
-func parseTargetsFile(r io.Reader) ([][]string, error) {
+func validateFields(fields []string) error {
+	if len(fields) < 2 {
+		return fmt.Errorf("invalid format")
+	}
+
+	resourceParts := strings.Split(fields[0], "/")
+	if len(resourceParts) > 2 {
+		return fmt.Errorf("unknown resource: %q", fields[0])
+	}
+
+	if resourceParts[0] == "ip" {
+		isInvalid := net.ParseIP(resourceParts[1]) == nil
+		if isInvalid {
+			return fmt.Errorf("invalid IP address: %q", resourceParts[1])
+		}
+	}
+	return nil
+}
+
+type target struct {
+	resource  string
+	ports     []string
+	namespace string
+}
+
+// TODO: specify namespace in targets file
+func parseTargetsFile(r io.Reader, defaultNamespace string) ([]target, error) {
 	s := bufio.NewScanner(r)
-	var ret [][]string
+	var ret []target
 	lineNo := 0
 	for s.Scan() {
 		lineNo++
@@ -220,26 +266,15 @@ func parseTargetsFile(r io.Reader) ([][]string, error) {
 		}
 
 		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			return nil, fmt.Errorf("line %d: invalid format", lineNo)
+		err := validateFields(fields)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNo, err)
 		}
-
-		resourceParts := strings.Split(fields[0], "/")
-		if len(resourceParts) > 2 {
-			return nil, fmt.Errorf("line: %d: unknown resource: %q", lineNo, fields[0])
-		}
-
-		switch resourceParts[0] {
-		case "ip":
-			isInvalid := net.ParseIP(resourceParts[1]) == nil
-			if isInvalid {
-				return nil, fmt.Errorf("line %d: invalid IP address: %q", lineNo, resourceParts[1])
-			}
-
-		case "host":
-		}
-		ret = append(ret, fields)
+		ret = append(ret, target{
+			resource:  fields[0],
+			ports:     fields[1:],
+			namespace: defaultNamespace,
+		})
 	}
-
 	return ret, nil
 }

--- a/cmd/client/utils_test.go
+++ b/cmd/client/utils_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTargetsFile(t *testing.T) {
+	testCases := map[string]struct {
+		input     string
+		expect    [][]string
+		expectErr string
+	}{
+		"normal": {
+			input: `bar 53@udp 53@tcp`,
+			expect: [][]string{
+				{"bar", "53@udp", "53@tcp"},
+			},
+		},
+		"comment & empty line": {
+			input: `
+# comment
+ip/1.2.3.4 8080
+// comment
+host/google.com 443@tcp
+
+pod/foo 8000 8001
+`,
+			expect: [][]string{
+				{"ip/1.2.3.4", "8080"},
+				{"host/google.com", "443@tcp"},
+				{"pod/foo", "8000", "8001"},
+			},
+		},
+		"invalid ip": {
+			input:     `ip/1.2.3 8080`,
+			expectErr: "invalid IP address",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if len(tc.expectErr) == 0 {
+				got, err := parseTargetsFile(strings.NewReader(tc.input))
+				require.NoError(t, err)
+				require.Equal(t, tc.expect, got)
+				return
+			}
+
+			_, err := parseTargetsFile(strings.NewReader(tc.input))
+			require.Error(t, err)
+			t.Logf("error: %v", err)
+			require.ErrorContains(t, err, tc.expectErr)
+		})
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,9 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"net"
-	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -129,9 +126,7 @@ func main() {
 	c := cobra.Command{
 		Use: constants.ServerName,
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
-			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, os.Interrupt)
-			defer cancel()
-			return o.run(ctx)
+			return o.run(context.TODO())
 		},
 		SilenceUsage: true,
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/knight42/krelay
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/spf13/cobra v1.8.0

--- a/manifests/Dockerfile-server
+++ b/manifests/Dockerfile-server
@@ -1,4 +1,4 @@
-FROM golang:1.21.0 AS builder
+FROM golang:1.22.0 AS builder
 WORKDIR /workspace
 ADD . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags '-w -s' -o krelay-server ./cmd/server

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -44,4 +44,4 @@ roleRef:
   name: krelay
 subjects:
 - kind: User
-  name: bob
+  name: <Please fill in your username here>


### PR DESCRIPTION
Signed-off-by: Jian Zeng <anonymousknight96@gmail.com>

Fix #25 

This PR adds a new flag `-f/--file` to `krelay`. If this flag is set, `krelay` will read targets from the given file, one target per line. For instance:
```
$ cat targets.txt
svc/nginx 8080:80
ip/192.168.194.245 8081:80

$ ./krelay -f targets.txt
I0325 23:52:12.067124   53088 main.go:148] "Creating krelay-server" namespace="default"
I0325 23:52:15.403953   53088 main.go:159] "krelay-server is running" pod="krelay-server-p2g7g" namespace="default"
I0325 23:52:15.427284   53088 forwarder.go:60] "Forwarding" protocol="tcp" localAddr="127.0.0.1:8081" remotePort=80
I0325 23:52:15.427312   53088 forwarder.go:60] "Forwarding" protocol="tcp" localAddr="127.0.0.1:8080" remotePort=80
```

TODO:
* [x] specify namespace of the object in the targets's file