### PR TITLE
Mark krelay servers as safe to evict by the cluster autoscaler

### DIFF
--- a/cmd/client/utils.go
+++ b/cmd/client/utils.go
@@ -44,6 +44,9 @@ func createServerPod(ctx context.Context, cs kubernetes.Interface, svrImg, names
 				"app.kubernetes.io/name": constants.ServerName,
 				"app":                    constants.ServerName,
 			},
+			Annotations: map[string]string{
+				"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+			},
 		},
 		Spec: corev1.PodSpec{
 			AutomountServiceAccountToken: toPtr(false),


### PR DESCRIPTION
The kubernetes cluster autoscaler doesn't remove pods that are not backed by a controller object (so not created by deployment, replica set, job, stateful set etc), thus without this annotation, krelay is preventing it from removing a node