### PR TITLE
docs: add CLAUDE.md and refresh README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+`krelay` is a `kubectl port-forward` replacement (installed as `kubectl-relay`) with UDP, multi-target, and in-cluster IP/hostname support. See `README.md` for user-facing docs and `docs/ARCHITECTURE.md` for internals.
+
+## Commands
+
+- `make krelay` — build client. Install as `$GOPATH/bin/kubectl-relay` so `kubectl relay` picks it up.
+- `make test` — `go test -race -v ./...`. Single test: `go test -race -run TestName ./pkg/xnet/...`.
+- `make lint` — `golangci-lint run`.
+- `make server-image` — build `ghcr.io/knight42/krelay-server` from `manifests/Dockerfile-server`.
+
+Go 1.25. Release via GoReleaser + Krew (`.goreleaser.yaml`, `.krew.yaml`).
+
+## Orientation
+
+Two binaries cooperate over a single Kubernetes port-forward stream: **client** (`cmd/client`) runs locally, **server** (`cmd/server`) runs as a pod the client creates/deletes in the user's cluster. Each local connection becomes a multiplexed stream framed with a custom header (`pkg/xnet/header.go`) that tells the server the real destination.
+
+- Wire protocol + proxy: `pkg/xnet`
+- Destination resolution (static / dynamic pod watch): `pkg/remoteaddr`
+- Port parsing: `pkg/ports`
+- Server-pod lifecycle and SPDY/websocket dialer: `pkg/kube`
+
+## Gotchas
+
+- `pkg/slog/` is exempt from `revive` var-naming (`.golangci.yaml`).
+- SPDY-over-websocket is tried first; set `KUBECTL_PORT_FORWARD_WEBSOCKETS=false` to force plain SPDY.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![GitHub](https://img.shields.io/github/license/knight42/krelay)
-![](https://github.com/knight42/krelay/actions/workflows/test.yml/badge.svg)
+![](https://github.com/knight42/krelay/actions/workflows/pr-presubmit-checks.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/knight42/krelay)](https://goreportcard.com/report/github.com/knight42/krelay)
 ![GitHub last commit](https://img.shields.io/github/last-commit/knight42/krelay)
 
@@ -23,6 +23,7 @@
 * Forwarding data to the given IP or hostname that is accessible within the kubernetes cluster
   * You could forward a local port to a port in the `Service` or a workload like `Deployment` or `StatefulSet`, and the forwarding session will not be interfered even if you perform rolling updates.
   * The hostname is resolved inside the cluster, so you don't need to change your local nameserver or modify the `/etc/hosts`.
+* Run a local SOCKS5 proxy that tunnels arbitrary TCP traffic into the cluster (`kubectl relay proxy`).
 
 ## Demo
 
@@ -130,17 +131,25 @@ kubectl relay ip/1.2.3.4 5000@tcp 6000@udp
 # Customized the server, and forward local port 5000 to "1.2.3.4:5000"
 kubectl relay --patch '{"metadata":{"namespace":"kube-public"},"spec":{"nodeSelector":{"k": "v"}}}' ip/1.2.3.4 5000
 
+# Run a SOCKS5 proxy on 127.0.0.1:1080 that tunnels TCP traffic into the cluster
+kubectl relay proxy
 ```
 
 ## Flags
 
-| flag             | default                                 | description                                                             |
-|------------------|-----------------------------------------|-------------------------------------------------------------------------|
-| `--address`      | `127.0.0.1`                             | Address to listen on. Only accepts IP addresses as a value.             |
-| `-f`/`--file`    | N/A                                     | Forward traffic to the targets specified in the given file.             |
-| `--server.image` | `ghcr.io/knight42/krelay-server:v0.0.1` | The krelay-server image to use.                                         |
-| `-p`/`--patch`   | N/A                                     | The merge patch to be applied to the krelay-server pod.                 |
-| `--patch-file`   | N/A                                     | A file containing a merge patch to be applied to the krelay-server pod. |
+Standard `kubectl` flags such as `--kubeconfig`, `-n`/`--namespace`, `--context` and `--cluster` are also accepted.
+
+| flag               | default                                 | description                                                             |
+|--------------------|-----------------------------------------|-------------------------------------------------------------------------|
+| `-l`/`--address`   | `127.0.0.1`                             | Address to listen on. Only accepts IP addresses as a value.             |
+| `-f`/`--file`      | N/A                                     | Forward traffic to the targets specified in the given file.             |
+| `-p`/`--patch`     | N/A                                     | The merge patch to be applied to the krelay-server pod.                 |
+| `--patch-file`     | N/A                                     | A file containing a merge patch to be applied to the krelay-server pod. |
+| `--server.image`   | `ghcr.io/knight42/krelay-server:v0.0.4` | The krelay-server image to use.                                         |
+| `-v`/`--v`         | `3`                                     | Log level verbosity. Higher is more verbose.                            |
+| `-V`/`--version`   | N/A                                     | Print version info and exit.                                            |
+
+The `proxy` subcommand takes `-l`/`--listen` (default `127.0.0.1:1080`) to set the SOCKS5 listen address.
 
 ## How It Works
 
@@ -171,3 +180,5 @@ The `Header` looks like this:
   * 4 bytes for IPv4 address
   * 16 bytes for IPv6 address
   * Variable bytes for hostname
+
+For a deeper dive into the client/server split, service targeting rules, and the server-pod spec, see [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,47 @@
+# Architecture
+
+`krelay` has two binaries that cooperate over a Kubernetes port-forward stream.
+
+## Client (`cmd/client`)
+
+Binary: `kubectl-relay`. Parses `TYPE/NAME [LOCAL:]REMOTE[@PROTO]` args (or `-f targets.txt`), resolves each target to a remote address, creates a `krelay-server` pod in the active namespace, opens a single SPDY (or SPDY-over-websocket) stream via the `/portforward` subresource, and listens locally for TCP/UDP. The pod is deleted with `GracePeriodSeconds: 0` on exit.
+
+Each local connection becomes a new multiplexed stream on that connection. UDP packets are length-prefixed over the same TCP-backed stream, with a per-client conntrack table (`cmd/client/conntrack.go`) routing replies back.
+
+Subcommand `kubectl relay proxy` (`cmd/client/command_proxy.go`) runs a local SOCKS5 server that tunnels through the same pod.
+
+## Server (`cmd/server`)
+
+Image: `ghcr.io/knight42/krelay-server` (distroless, nonroot). Listens on `constants.ServerPort` (9527), reads an `xnet.Header`, dials the real destination (TCP or UDP), writes an `xnet.Acknowledgement`, then shovels bytes via `xnet.ProxyTCP` / `xnet.ProxyUDP`.
+
+## Wire protocol (`pkg/xnet/header.go`)
+
+```
+version(1) | total length(2) | request id(5) | protocol(1) | port(2) | addr type(1) | addr(variable)
+```
+
+- protocol: `0`=TCP, `1`=UDP
+- addr type: `0`=IP (4 bytes IPv4, 16 bytes IPv6), `1`=hostname (raw bytes; length is implied by total length − 12)
+- ack codes: `AckCodeOK`, `AckCodeNoSuchHost`, `AckCodeResolveTimeout`, `AckCodeConnectTimeout`, `AckCodeUnknownProtocol`, `AckCodeUnknownError` — mapped from server-side `net.DNSError` / `net.OpError` in `cmd/server/main.go:ackCodeFromErr`.
+
+## Service targeting
+
+`cmd/client/utils.go:addrGetterForObject` picks a destination in this order for `svc/X`:
+
+1. `Spec.Type == ExternalName` → `Spec.ExternalName` (hostname).
+2. `Spec.ClusterIP` set and not `None` → cluster IP (static).
+3. Otherwise → dynamic pod watch matching `Spec.Selector`.
+
+For workloads (Deployment / StatefulSet / ReplicaSet / DaemonSet), the dynamic watcher keeps the forwarding session alive across rolling updates.
+
+## Server-pod spec
+
+`pkg/kube/flags.go:buildServerPod` produces a minimal pod: non-root, read-only rootfs, no service-account token, no service links, with a `TopologySpreadConstraint` on `kubernetes.io/hostname`. `--patch` / `--patch-file` (JSON or YAML merge patch) is applied before creation to let users override namespace, add nodeSelector, etc.
+
+## Packages
+
+- `pkg/kube` — pod lifecycle, REST config, SPDY-over-websocket dialer with SPDY fallback.
+- `pkg/remoteaddr` — `Getter` interface; `static.go` for fixed IP/host, `dynamic.go` for pod-selector watches.
+- `pkg/ports` — parses `8080:http`, `:53@udp`, etc. Uses the target object to resolve named ports and infer protocol.
+- `pkg/xnet` — wire protocol, ack, `AddrPort`, `ProxyTCP`/`ProxyUDP`.
+- `pkg/xio`, `pkg/alarm`, `pkg/slog`, `pkg/constants` — small helpers.


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with build/test commands and orientation for Claude Code instances.
- Split deeper internals (wire protocol, service-targeting rules, server-pod spec, package map) into `docs/ARCHITECTURE.md`, linked from both `CLAUDE.md` and the README's *How It Works* section — progressive disclosure rather than bloating either file.
- Refresh `README.md` to reflect current state:
  - Document the `kubectl relay proxy` SOCKS5 subcommand (highlights + usage example + `-l/--listen` flag note).
  - Bump `--server.image` default to `v0.0.4` (matches `pkg/kube/flags.go:49`).
  - Add `-v/--v`, `-V/--version`, and `-l` shorthand to the flags table; call out that standard kubectl flags (`--kubeconfig`, `-n`, `--context`, `--cluster`) pass through.
  - Fix the CI badge URL (`test.yml` → `pr-presubmit-checks.yml`).

## Test plan
- [ ] Render `README.md` on GitHub and confirm the CI badge, flags table, and new proxy example look right.
- [ ] Confirm the `docs/ARCHITECTURE.md` link from both `CLAUDE.md` and `README.md` resolves.
- [ ] Spot-check the wire-protocol description in `docs/ARCHITECTURE.md` against `pkg/xnet/header.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)