### PR TITLE
feat: manage krelay-server via Job with idle-timeout self-exit

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,7 @@ linters:
     - goconst
     - gocritic
     - misspell
+    - modernize
     - nolintlint
     - prealloc
     - revive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `make server-image` — build `ghcr.io/knight42/krelay-server` from `manifests/Dockerfile-server`.
 - `make test-e2e` — run e2e tests against a live k8s cluster (`go test -count=1 -tags e2e ./test/e2e/`). Set `KRELAY_SERVER_IMAGE` to override the server image.
 
-Go 1.25. Release via GoReleaser + Krew (`.goreleaser.yaml`, `.krew.yaml`).
+Go 1.26. Release via GoReleaser + Krew (`.goreleaser.yaml`, `.krew.yaml`).
 
 ## Orientation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,7 @@ Every new user-facing feature must include corresponding e2e tests in `test/e2e/
 - `pkg/slog/` is exempt from `revive` var-naming (`.golangci.yaml`).
 - SPDY-over-websocket is tried first; set `KUBECTL_PORT_FORWARD_WEBSOCKETS=false` to force plain SPDY.
 - Register cobra flags with `cmd.Flags()`, not `cmd.LocalFlags()`. `LocalFlags()` returns a computed set that doesn't participate in parsing.
+- When using atomics for connection tracking, update `lastActivity` **before** decrementing `activeConns` in disconnect paths — otherwise a monitor goroutine can see zero connections with a stale timestamp and shut down prematurely.
+- `createStream()` spawns a goroutine that sends on an unbuffered `errCh`. Callers that discard `errCh` must drain it (`go func() { <-errCh }()`) to avoid leaking that goroutine.
+- `RunServerJob` must clean up the Job on every error path after `Jobs().Create()` — the caller never gets a `ServerJob` handle to call `Close()` on if setup fails, and `ttlSecondsAfterFinished` only applies to finished Jobs (not stuck-Pending ones).
+- E2e tests with a local server image require `imagePullPolicy: IfNotPresent` in the pod patch; the code defaults to `Always` which fails for images not in a registry. Set `KRELAY_SERVER_IMAGE` and use `serverPodPatchWithArgs()` in test helpers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Two binaries cooperate over a single Kubernetes port-forward stream: **client** 
 - Wire protocol + proxy: `pkg/xnet`
 - Destination resolution (static / dynamic pod watch): `pkg/remoteaddr`
 - Port parsing: `pkg/ports`
-- Server-pod lifecycle and SPDY/websocket dialer: `pkg/kube`
+- Server `batch/v1.Job` lifecycle and SPDY/websocket dialer: `pkg/kube`
 
 ## Testing policy
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Standard `kubectl` flags such as `--kubeconfig`, `-n`/`--namespace`, `--context`
 | `-f`/`--file`      | N/A                                     | Forward traffic to the targets specified in the given file.             |
 | `-p`/`--patch`     | N/A                                     | The merge patch to be applied to the krelay-server pod.                 |
 | `--patch-file`     | N/A                                     | A file containing a merge patch to be applied to the krelay-server pod. |
-| `--server.image`   | `ghcr.io/knight42/krelay-server:v0.0.4` | The krelay-server image to use.                                         |
+| `--server.image`   | `ghcr.io/knight42/krelay-server:v0.0.5` | The krelay-server image to use.                                         |
 | `-v`/`--v`         | `3`                                     | Log level verbosity. Higher is more verbose.                            |
 | `-V`/`--version`   | N/A                                     | Print version info and exit.                                            |
 

--- a/cmd/client/command_proxy.go
+++ b/cmd/client/command_proxy.go
@@ -159,7 +159,7 @@ func (o *proxyOptions) Run(ctx context.Context, _ []string) error {
 	defer createdJob.Close()
 
 	streamConn := createdJob.StreamConn()
-	openKeepalive(streamConn)
+	go sendHeartbeats(streamConn)
 	go runSOCKS5Server(l, streamConn)
 
 	select {

--- a/cmd/client/command_proxy.go
+++ b/cmd/client/command_proxy.go
@@ -159,6 +159,7 @@ func (o *proxyOptions) Run(ctx context.Context, _ []string) error {
 	defer createdJob.Close()
 
 	streamConn := createdJob.StreamConn()
+	openKeepalive(streamConn)
 	go runSOCKS5Server(l, streamConn)
 
 	select {

--- a/cmd/client/command_proxy.go
+++ b/cmd/client/command_proxy.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/httpstream"
@@ -159,7 +160,7 @@ func (o *proxyOptions) Run(ctx context.Context, _ []string) error {
 	defer createdJob.Close()
 
 	streamConn := createdJob.StreamConn()
-	go sendHeartbeats(streamConn)
+	go sendHeartbeats(streamConn, 5*time.Second)
 	go runSOCKS5Server(l, streamConn)
 
 	select {

--- a/cmd/client/command_proxy.go
+++ b/cmd/client/command_proxy.go
@@ -151,14 +151,14 @@ func (o *proxyOptions) Run(ctx context.Context, _ []string) error {
 	}
 	defer l.Close()
 
-	createdPod, err := o.kf.RunServerPod(ctx)
+	createdJob, err := o.kf.RunServerJob(ctx)
 	if err != nil {
 		return err
 	}
 
-	defer createdPod.Close()
+	defer createdJob.Close()
 
-	streamConn := createdPod.StreamConn()
+	streamConn := createdJob.StreamConn()
 	go runSOCKS5Server(l, streamConn)
 
 	select {

--- a/cmd/client/heartbeat_test.go
+++ b/cmd/client/heartbeat_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+type fakeStream struct {
+	written []byte
+	closed  atomic.Bool
+}
+
+func (s *fakeStream) Read([]byte) (int, error) { return 0, io.EOF }
+func (s *fakeStream) Write(p []byte) (int, error) {
+	s.written = append(s.written, p...)
+	return len(p), nil
+}
+func (s *fakeStream) Close() error         { s.closed.Store(true); return nil }
+func (s *fakeStream) Reset() error         { return nil }
+func (s *fakeStream) Headers() http.Header { return nil }
+func (s *fakeStream) Identifier() uint32   { return 0 }
+
+type fakeConn struct {
+	closeCh        chan bool
+	createCount    atomic.Int32
+	createErr      error
+	createWriteErr bool
+}
+
+func newFakeConn() *fakeConn {
+	return &fakeConn{closeCh: make(chan bool)}
+}
+
+func (c *fakeConn) CreateStream(_ http.Header) (httpstream.Stream, error) {
+	if c.createErr != nil {
+		return nil, c.createErr
+	}
+	c.createCount.Add(1)
+	s := &fakeStream{}
+	if c.createWriteErr {
+		return &errorStream{fakeStream: s}, nil
+	}
+	return s, nil
+}
+
+func (c *fakeConn) Close() error                       { return nil }
+func (c *fakeConn) CloseChan() <-chan bool             { return c.closeCh }
+func (c *fakeConn) SetIdleTimeout(time.Duration)       {}
+func (c *fakeConn) RemoveStreams(...httpstream.Stream) {}
+
+type errorStream struct {
+	*fakeStream
+}
+
+func (s *errorStream) Write([]byte) (int, error) {
+	return 0, errors.New("broken pipe")
+}
+
+func TestSendHeartbeats_CloseChan(t *testing.T) {
+	conn := newFakeConn()
+	close(conn.closeCh)
+
+	done := make(chan struct{})
+	go func() {
+		sendHeartbeats(conn, 10*time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("sendHeartbeats did not return after CloseChan was closed")
+	}
+	assert.Equal(t, int32(0), conn.createCount.Load())
+}
+
+func TestSendHeartbeats_SendsHeartbeats(t *testing.T) {
+	conn := newFakeConn()
+
+	done := make(chan struct{})
+	go func() {
+		sendHeartbeats(conn, 10*time.Millisecond)
+		close(done)
+	}()
+
+	time.Sleep(55 * time.Millisecond)
+	close(conn.closeCh)
+	<-done
+
+	// createStream is called twice per heartbeat (error stream + data stream)
+	count := conn.createCount.Load()
+	assert.GreaterOrEqual(t, count, int32(4), "expected at least 2 heartbeats (4 streams), got %d streams", count)
+}
+
+func TestSendHeartbeats_CreateStreamError(t *testing.T) {
+	conn := newFakeConn()
+	conn.createErr = errors.New("connection refused")
+
+	done := make(chan struct{})
+	go func() {
+		sendHeartbeats(conn, 10*time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("sendHeartbeats did not return after CreateStream error")
+	}
+}
+
+func TestSendHeartbeats_WriteError(t *testing.T) {
+	conn := newFakeConn()
+	conn.createWriteErr = true
+
+	done := make(chan struct{})
+	go func() {
+		sendHeartbeats(conn, 10*time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("sendHeartbeats did not return after write error")
+	}
+}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -151,7 +152,7 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 	defer createdJob.Close()
 
 	streamConn := createdJob.StreamConn()
-	go sendHeartbeats(streamConn)
+	go sendHeartbeats(streamConn, 5*time.Second)
 	for _, pf := range portForwarders {
 		go pf.run(streamConn)
 	}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -151,7 +151,7 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 	defer createdJob.Close()
 
 	streamConn := createdJob.StreamConn()
-	openKeepalive(streamConn)
+	go sendHeartbeats(streamConn)
 	for _, pf := range portForwarders {
 		go pf.run(streamConn)
 	}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -144,13 +144,13 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("unable to listen on any of the requested ports")
 	}
 
-	createdPod, err := o.kf.RunServerPod(ctx)
+	createdJob, err := o.kf.RunServerJob(ctx)
 	if err != nil {
 		return err
 	}
-	defer createdPod.Close()
+	defer createdJob.Close()
 
-	streamConn := createdPod.StreamConn()
+	streamConn := createdJob.StreamConn()
 	for _, pf := range portForwarders {
 		go pf.run(streamConn)
 	}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -151,6 +151,7 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 	defer createdJob.Close()
 
 	streamConn := createdJob.StreamConn()
+	openKeepalive(streamConn)
 	for _, pf := range portForwarders {
 		go pf.run(streamConn)
 	}

--- a/cmd/client/utils.go
+++ b/cmd/client/utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/knight42/krelay/pkg/constants"
 	"github.com/knight42/krelay/pkg/remoteaddr"
+	slogutil "github.com/knight42/krelay/pkg/slog"
 	"github.com/knight42/krelay/pkg/xio"
 	"github.com/knight42/krelay/pkg/xnet"
 )
@@ -39,13 +41,16 @@ func sendHeartbeats(c httpstream.Connection) {
 			reqID := xnet.NewRequestID()
 			stream, _, err := createStream(c, reqID)
 			if err != nil {
+				slog.Error("Fail to create heartbeat stream", slogutil.Error(err))
 				return
 			}
 			hdr := xnet.Header{
 				RequestID: reqID,
 				Protocol:  xnet.ProtocolKeepalive,
 			}
-			_, _ = xio.WriteFull(stream, hdr.Marshal())
+			if _, err := xio.WriteFull(stream, hdr.Marshal()); err != nil {
+				slog.Error("Fail to send heartbeat", slogutil.Error(err))
+			}
 			_ = stream.Close()
 		}
 	}

--- a/cmd/client/utils.go
+++ b/cmd/client/utils.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/pflag"
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,22 +28,27 @@ import (
 	"github.com/knight42/krelay/pkg/xnet"
 )
 
-// openKeepalive opens a long-lived stream on the port-forward connection so
-// the server can detect when the tunnel drops. The stream counts as an active
-// connection on the server side, preventing its idle timer from firing as long
-// as the port-forward is alive.
-func openKeepalive(c httpstream.Connection) {
-	reqID := xnet.NewRequestID()
-	stream, _, err := createStream(c, reqID)
-	if err != nil {
-		return
+func sendHeartbeats(c httpstream.Connection) {
+	tick := time.NewTicker(5 * time.Second)
+	defer tick.Stop()
+	for {
+		select {
+		case <-c.CloseChan():
+			return
+		case <-tick.C:
+			reqID := xnet.NewRequestID()
+			stream, _, err := createStream(c, reqID)
+			if err != nil {
+				return
+			}
+			hdr := xnet.Header{
+				RequestID: reqID,
+				Protocol:  xnet.ProtocolKeepalive,
+			}
+			_, _ = xio.WriteFull(stream, hdr.Marshal())
+			_ = stream.Close()
+		}
 	}
-	hdr := xnet.Header{
-		RequestID: reqID,
-		Protocol:  xnet.ProtocolKeepalive,
-	}
-	_, _ = xio.WriteFull(stream, hdr.Marshal())
-	// stream stays open until the connection closes — do not defer Close.
 }
 
 func copyBuffer(b []byte) []byte {

--- a/cmd/client/utils.go
+++ b/cmd/client/utils.go
@@ -23,8 +23,27 @@ import (
 
 	"github.com/knight42/krelay/pkg/constants"
 	"github.com/knight42/krelay/pkg/remoteaddr"
+	"github.com/knight42/krelay/pkg/xio"
 	"github.com/knight42/krelay/pkg/xnet"
 )
+
+// openKeepalive opens a long-lived stream on the port-forward connection so
+// the server can detect when the tunnel drops. The stream counts as an active
+// connection on the server side, preventing its idle timer from firing as long
+// as the port-forward is alive.
+func openKeepalive(c httpstream.Connection) {
+	reqID := xnet.NewRequestID()
+	stream, _, err := createStream(c, reqID)
+	if err != nil {
+		return
+	}
+	hdr := xnet.Header{
+		RequestID: reqID,
+		Protocol:  xnet.ProtocolKeepalive,
+	}
+	_, _ = xio.WriteFull(stream, hdr.Marshal())
+	// stream stays open until the connection closes — do not defer Close.
+}
 
 func copyBuffer(b []byte) []byte {
 	c := make([]byte, len(b))

--- a/cmd/client/utils.go
+++ b/cmd/client/utils.go
@@ -39,11 +39,12 @@ func sendHeartbeats(c httpstream.Connection) {
 			return
 		case <-tick.C:
 			reqID := xnet.NewRequestID()
-			stream, _, err := createStream(c, reqID)
+			stream, errCh, err := createStream(c, reqID)
 			if err != nil {
 				slog.Error("Fail to create heartbeat stream", slogutil.Error(err))
 				return
 			}
+			go func() { <-errCh }()
 			hdr := xnet.Header{
 				RequestID: reqID,
 				Protocol:  xnet.ProtocolKeepalive,

--- a/cmd/client/utils.go
+++ b/cmd/client/utils.go
@@ -30,8 +30,8 @@ import (
 	"github.com/knight42/krelay/pkg/xnet"
 )
 
-func sendHeartbeats(c httpstream.Connection) {
-	tick := time.NewTicker(5 * time.Second)
+func sendHeartbeats(c httpstream.Connection, interval time.Duration) {
+	tick := time.NewTicker(interval)
 	defer tick.Stop()
 	for {
 		select {

--- a/cmd/client/utils.go
+++ b/cmd/client/utils.go
@@ -50,6 +50,8 @@ func sendHeartbeats(c httpstream.Connection) {
 			}
 			if _, err := xio.WriteFull(stream, hdr.Marshal()); err != nil {
 				slog.Error("Fail to send heartbeat", slogutil.Error(err))
+				_ = stream.Close()
+				return
 			}
 			_ = stream.Close()
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -42,8 +42,11 @@ func (t *idleTracker) onConnect() {
 }
 
 func (t *idleTracker) onDisconnect() {
-	t.activeConns.Add(-1)
+	// Update lastActivity before decrementing activeConns so the monitor
+	// never sees activeConns==0 with a stale timestamp from before the
+	// connection was established.
 	t.lastActivity.Store(time.Now().UnixNano())
+	t.activeConns.Add(-1)
 }
 
 func (t *idleTracker) monitor(ctx context.Context, lis net.Listener) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -28,6 +28,10 @@ type idleTracker struct {
 	timeout      time.Duration
 	activeConns  atomic.Int64
 	lastActivity atomic.Int64
+	// hadConn becomes true after the first connection is accepted.
+	// The idle timer only fires after this — so the server never
+	// exits before a client has connected at least once.
+	hadConn atomic.Bool
 }
 
 func newIdleTracker(timeout time.Duration) *idleTracker {
@@ -37,6 +41,7 @@ func newIdleTracker(timeout time.Duration) *idleTracker {
 }
 
 func (t *idleTracker) onConnect() {
+	t.hadConn.Store(true)
 	t.activeConns.Add(1)
 	t.lastActivity.Store(time.Now().UnixNano())
 }
@@ -58,7 +63,7 @@ func (t *idleTracker) monitor(ctx context.Context, lis net.Listener) {
 		case <-ctx.Done():
 			return
 		case <-tick.C:
-			if t.activeConns.Load() > 0 {
+			if !t.hadConn.Load() || t.activeConns.Load() > 0 {
 				continue
 			}
 			idle := time.Since(time.Unix(0, t.lastActivity.Load()))
@@ -208,7 +213,7 @@ func main() {
 	}
 	flags := c.Flags()
 	flags.DurationVar(&o.connectTimeout, "connect-timeout", time.Second*10, "Timeout for connecting to upstream")
-	flags.DurationVar(&o.idleTimeout, "idle-timeout", time.Hour, "Exit when no connections have been active for this duration. 0 disables.")
+	flags.DurationVar(&o.idleTimeout, "idle-timeout", 5*time.Minute, "Exit when no connections have been active for this duration after the last client disconnects. 0 disables.")
 	flags.IntP("v", "v", 0, "bogus flag to keep backward compatibility. This flag will be removed in the future.")
 	_ = c.Execute()
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -28,10 +28,6 @@ type idleTracker struct {
 	timeout      time.Duration
 	activeConns  atomic.Int64
 	lastActivity atomic.Int64
-	// hadConn becomes true after the first connection is accepted.
-	// The idle timer only fires after this — so the server never
-	// exits before a client has connected at least once.
-	hadConn atomic.Bool
 }
 
 func newIdleTracker(timeout time.Duration) *idleTracker {
@@ -41,7 +37,6 @@ func newIdleTracker(timeout time.Duration) *idleTracker {
 }
 
 func (t *idleTracker) onConnect() {
-	t.hadConn.Store(true)
 	t.activeConns.Add(1)
 	t.lastActivity.Store(time.Now().UnixNano())
 }
@@ -63,7 +58,7 @@ func (t *idleTracker) monitor(ctx context.Context, lis net.Listener) {
 		case <-ctx.Done():
 			return
 		case <-tick.C:
-			if !t.hadConn.Load() || t.activeConns.Load() > 0 {
+			if t.activeConns.Load() > 0 {
 				continue
 			}
 			idle := time.Since(time.Unix(0, t.lastActivity.Load()))
@@ -191,13 +186,7 @@ func handleConn(ctx context.Context, c *net.TCPConn, dialer *net.Dialer) {
 		xnet.ProxyUDP(hdr.RequestID, c, udpConn)
 
 	case xnet.ProtocolKeepalive:
-		l.Info("Keepalive stream established")
-		// Block until the port-forward connection drops.
-		// This stream counts as activeConns=1, preventing the idle
-		// timer from firing as long as the tunnel is alive.
-		var buf [1]byte
-		_, _ = c.Read(buf[:])
-		l.Info("Keepalive stream closed")
+		l.Debug("Heartbeat received")
 
 	default:
 		l.Error("Unknown protocol", slog.String(constants.LogFieldDestAddr, dstAddr), slog.Any(constants.LogFieldProtocol, hdr.Protocol))

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -17,6 +18,57 @@ import (
 
 type options struct {
 	connectTimeout time.Duration
+	idleTimeout    time.Duration
+}
+
+// idleTracker closes the listener when no connections have been active for
+// idleTimeout, so the Job can transition to Complete and be garbage-collected
+// by its TTL if the client crashed without cleaning up.
+type idleTracker struct {
+	timeout      time.Duration
+	activeConns  atomic.Int64
+	lastActivity atomic.Int64
+}
+
+func newIdleTracker(timeout time.Duration) *idleTracker {
+	t := &idleTracker{timeout: timeout}
+	t.lastActivity.Store(time.Now().UnixNano())
+	return t
+}
+
+func (t *idleTracker) onConnect() {
+	t.activeConns.Add(1)
+	t.lastActivity.Store(time.Now().UnixNano())
+}
+
+func (t *idleTracker) onDisconnect() {
+	t.activeConns.Add(-1)
+	t.lastActivity.Store(time.Now().UnixNano())
+}
+
+func (t *idleTracker) monitor(ctx context.Context, lis net.Listener) {
+	if t.timeout <= 0 {
+		return
+	}
+	interval := max(t.timeout/4, time.Second)
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			if t.activeConns.Load() > 0 {
+				continue
+			}
+			idle := time.Since(time.Unix(0, t.lastActivity.Load()))
+			if idle >= t.timeout {
+				slog.Info("Idle timeout reached, shutting down", slog.Duration("idle", idle))
+				_ = lis.Close()
+				return
+			}
+		}
+	}
 }
 
 func (o *options) run(ctx context.Context) error {
@@ -27,10 +79,18 @@ func (o *options) run(ctx context.Context) error {
 	defer tcpListener.Close()
 
 	dialer := net.Dialer{Timeout: o.connectTimeout}
-	slog.Info("Accepting connections")
+	tracker := newIdleTracker(o.idleTimeout)
+	monitorCtx, cancelMonitor := context.WithCancel(ctx)
+	defer cancelMonitor()
+	go tracker.monitor(monitorCtx, tcpListener)
+
+	slog.Info("Accepting connections", slog.Duration("idleTimeout", o.idleTimeout))
 	for {
 		c, err := tcpListener.Accept()
 		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
 			var tmpErr interface {
 				Temporary() bool
 			}
@@ -40,7 +100,11 @@ func (o *options) run(ctx context.Context) error {
 			slog.Error("Fail to accept connection", slogutil.Error(err))
 			return err
 		}
-		go handleConn(ctx, c.(*net.TCPConn), &dialer)
+		tracker.onConnect()
+		go func(c *net.TCPConn) {
+			defer tracker.onDisconnect()
+			handleConn(ctx, c, &dialer)
+		}(c.(*net.TCPConn))
 	}
 }
 
@@ -144,6 +208,7 @@ func main() {
 	}
 	flags := c.Flags()
 	flags.DurationVar(&o.connectTimeout, "connect-timeout", time.Second*10, "Timeout for connecting to upstream")
+	flags.DurationVar(&o.idleTimeout, "idle-timeout", time.Hour, "Exit when no connections have been active for this duration. 0 disables.")
 	flags.IntP("v", "v", 0, "bogus flag to keep backward compatibility. This flag will be removed in the future.")
 	_ = c.Execute()
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -190,6 +190,15 @@ func handleConn(ctx context.Context, c *net.TCPConn, dialer *net.Dialer) {
 		udpConn := &xnet.UDPConn{UDPConn: upstreamConn.(*net.UDPConn)}
 		xnet.ProxyUDP(hdr.RequestID, c, udpConn)
 
+	case xnet.ProtocolKeepalive:
+		l.Info("Keepalive stream established")
+		// Block until the port-forward connection drops.
+		// This stream counts as activeConns=1, preventing the idle
+		// timer from firing as long as the tunnel is alive.
+		var buf [1]byte
+		_, _ = c.Read(buf[:])
+		l.Info("Keepalive stream closed")
+
 	default:
 		l.Error("Unknown protocol", slog.String(constants.LogFieldDestAddr, dstAddr), slog.Any(constants.LogFieldProtocol, hdr.Protocol))
 		err = writeACK(c, xnet.Acknowledgement{

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,7 +64,9 @@ func (t *idleTracker) monitor(ctx context.Context, lis net.Listener) {
 			idle := time.Since(time.Unix(0, t.lastActivity.Load()))
 			if idle >= t.timeout {
 				slog.Info("Idle timeout reached, shutting down", slog.Duration("idle", idle))
-				_ = lis.Close()
+				if err := lis.Close(); err != nil {
+					slog.Warn("Fail to close listener", slogutil.Error(err))
+				}
 				return
 			}
 		}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## Client (`cmd/client`)
 
-Binary: `kubectl-relay`. Parses `TYPE/NAME [LOCAL:]REMOTE[@PROTO]` args (or `-f targets.txt`), resolves each target to a remote address, creates a `krelay-server` **Job** in the active namespace, waits for the Job's pod to become Running, opens a single SPDY (or SPDY-over-websocket) stream via the `/portforward` subresource, and listens locally for TCP/UDP. On graceful exit the Job is deleted with `PropagationPolicy=Background`; on crash the server self-terminates on idle (see below) and the Job's `ttlSecondsAfterFinished` cleans it up.
+Binary: `kubectl-relay`. Parses `TYPE/NAME [LOCAL:]REMOTE[@PROTO]` args (or `-f targets.txt`), resolves each target to a remote address, creates a `krelay-server` **Job** in the default namespace (overridable via `--patch` / `--patch-file`), waits for the Job's pod to become Running, opens a single SPDY (or SPDY-over-websocket) stream via the `/portforward` subresource, and listens locally for TCP/UDP. On graceful exit the Job is deleted with `PropagationPolicy=Background`; on crash the server self-terminates on idle (see below) and the Job's `ttlSecondsAfterFinished` cleans it up.
 
 Each local connection becomes a new multiplexed stream on that connection. UDP packets are length-prefixed over the same TCP-backed stream, with a per-client conntrack table (`cmd/client/conntrack.go`) routing replies back.
 
@@ -24,7 +24,7 @@ The client sends a `ProtocolKeepalive` heartbeat every 5 seconds over the port-f
 version(1) | total length(2) | request id(5) | protocol(1) | port(2) | addr type(1) | addr(variable)
 ```
 
-- protocol: `0`=TCP, `1`=UDP
+- protocol: `0`=TCP, `1`=UDP, `2`=Keepalive (client heartbeat; server returns immediately)
 - addr type: `0`=IP (4 bytes IPv4, 16 bytes IPv6), `1`=hostname (raw bytes; length is implied by total length − 12)
 - ack codes: `AckCodeOK`, `AckCodeNoSuchHost`, `AckCodeResolveTimeout`, `AckCodeConnectTimeout`, `AckCodeUnknownProtocol`, `AckCodeUnknownError` — mapped from server-side `net.DNSError` / `net.OpError` in `cmd/server/main.go:ackCodeFromErr`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ Image: `ghcr.io/knight42/krelay-server` (distroless, nonroot). Listens on `const
 
 ### Idle timeout
 
-The server tracks active connections and the timestamp of the last connect/disconnect. If no connections have been active for `--idle-timeout` (default 1h), it closes the listener, `run()` returns nil, and the process exits 0 — the Job transitions to `Complete` and is garbage-collected by `ttlSecondsAfterFinished`. This is the safety net for the case where the client crashes without deleting the Job.
+The server tracks active connections and the timestamp of the last connect/disconnect. The idle timer only activates after the first connection has been accepted (so the server never exits before a client connects). Once all connections have closed, if no new connections arrive within `--idle-timeout` (default 5m), the server closes the listener, `run()` returns nil, and the process exits 0 — the Job transitions to `Complete` and is garbage-collected by `ttlSecondsAfterFinished`. This is the safety net for the case where the client crashes without deleting the Job.
 
 ## Wire protocol (`pkg/xnet/header.go`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## Client (`cmd/client`)
 
-Binary: `kubectl-relay`. Parses `TYPE/NAME [LOCAL:]REMOTE[@PROTO]` args (or `-f targets.txt`), resolves each target to a remote address, creates a `krelay-server` pod in the active namespace, opens a single SPDY (or SPDY-over-websocket) stream via the `/portforward` subresource, and listens locally for TCP/UDP. The pod is deleted with `GracePeriodSeconds: 0` on exit.
+Binary: `kubectl-relay`. Parses `TYPE/NAME [LOCAL:]REMOTE[@PROTO]` args (or `-f targets.txt`), resolves each target to a remote address, creates a `krelay-server` **Job** in the active namespace, waits for the Job's pod to become Running, opens a single SPDY (or SPDY-over-websocket) stream via the `/portforward` subresource, and listens locally for TCP/UDP. On graceful exit the Job is deleted with `PropagationPolicy=Background`; on crash the server self-terminates on idle (see below) and the Job's `ttlSecondsAfterFinished` cleans it up.
 
 Each local connection becomes a new multiplexed stream on that connection. UDP packets are length-prefixed over the same TCP-backed stream, with a per-client conntrack table (`cmd/client/conntrack.go`) routing replies back.
 
@@ -13,6 +13,10 @@ Subcommand `kubectl relay proxy` (`cmd/client/command_proxy.go`) runs a local SO
 ## Server (`cmd/server`)
 
 Image: `ghcr.io/knight42/krelay-server` (distroless, nonroot). Listens on `constants.ServerPort` (9527), reads an `xnet.Header`, dials the real destination (TCP or UDP), writes an `xnet.Acknowledgement`, then shovels bytes via `xnet.ProxyTCP` / `xnet.ProxyUDP`.
+
+### Idle timeout
+
+The server tracks active connections and the timestamp of the last connect/disconnect. If no connections have been active for `--idle-timeout` (default 1h), it closes the listener, `run()` returns nil, and the process exits 0 — the Job transitions to `Complete` and is garbage-collected by `ttlSecondsAfterFinished`. This is the safety net for the case where the client crashes without deleting the Job.
 
 ## Wire protocol (`pkg/xnet/header.go`)
 
@@ -36,11 +40,11 @@ For workloads (Deployment / StatefulSet / ReplicaSet / DaemonSet), the dynamic w
 
 ## Server-pod spec
 
-`pkg/kube/flags.go:buildServerPod` produces a minimal pod: non-root, read-only rootfs, no service-account token, no service links, with a `TopologySpreadConstraint` on `kubernetes.io/hostname`. `--patch` / `--patch-file` (JSON or YAML merge patch) is applied before creation to let users override namespace, add nodeSelector, etc.
+`pkg/kube/flags.go:buildServerJob` wraps a minimal pod template in a `batch/v1.Job` with `backoffLimit: 0`, `ttlSecondsAfterFinished: 10`, `restartPolicy: Never`. The pod itself is non-root, read-only rootfs, no service-account token, no service links, with a `TopologySpreadConstraint` on `kubernetes.io/hostname`. `--patch` / `--patch-file` (JSON or YAML merge patch) is applied to the pod spec — namespace set by the patch is propagated to the Job's metadata so users can still retarget the namespace with a pod-shaped patch.
 
 ## Packages
 
-- `pkg/kube` — pod lifecycle, REST config, SPDY-over-websocket dialer with SPDY fallback.
+- `pkg/kube` — Job lifecycle, REST config, SPDY-over-websocket dialer with SPDY fallback.
 - `pkg/remoteaddr` — `Getter` interface; `static.go` for fixed IP/host, `dynamic.go` for pod-selector watches.
 - `pkg/ports` — parses `8080:http`, `:53@udp`, etc. Uses the target object to resolve named ports and infer protocol.
 - `pkg/xnet` — wire protocol, ack, `AddrPort`, `ProxyTCP`/`ProxyUDP`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ Image: `ghcr.io/knight42/krelay-server` (distroless, nonroot). Listens on `const
 
 ### Idle timeout
 
-The server tracks active connections and the timestamp of the last connect/disconnect. The idle timer only activates after the first connection has been accepted (so the server never exits before a client connects). Once all connections have closed, if no new connections arrive within `--idle-timeout` (default 5m), the server closes the listener, `run()` returns nil, and the process exits 0 — the Job transitions to `Complete` and is garbage-collected by `ttlSecondsAfterFinished`. This is the safety net for the case where the client crashes without deleting the Job.
+The client sends a `ProtocolKeepalive` heartbeat every 5 seconds over the port-forward stream. Each heartbeat refreshes the server's `lastActivity` timestamp. When the port-forward drops (client exit or crash), heartbeats stop. If no connections (including heartbeats) arrive within `--idle-timeout` (default 5m), the server closes the listener, `run()` returns nil, and the process exits 0 — the Job transitions to `Complete` and is garbage-collected by `ttlSecondsAfterFinished`.
 
 ## Wire protocol (`pkg/xnet/header.go`)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/knight42/krelay
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/evanphx/json-patch/v5 v5.9.11

--- a/manifests/Dockerfile-server
+++ b/manifests/Dockerfile-server
@@ -1,4 +1,4 @@
-FROM golang:1.22.5 AS builder
+FROM golang:1.26 AS builder
 WORKDIR /workspace
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -27,7 +27,7 @@ rules:
   verbs:
   - create
 
-# The following permissions is only requried if you want to forward the local port to the respective objects.
+# The following permissions are only required if you want to forward the local port to the respective objects.
 - apiGroups:
   - ""
   resources:

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -3,18 +3,29 @@ kind: ClusterRole
 metadata:
   name: krelay
 rules:
+# create the krelay-server Job; clean it up on client exit (Job deletion
+# cascades to the pod via PropagationPolicy=Background).
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+# watch the Job's pod to learn its name and wait for it to become Running.
 - apiGroups:
   - ""
   resources:
   - pods
+  verbs:
+  - watch
+# open the port-forward stream to the krelay-server pod.
+- apiGroups:
+  - ""
+  resources:
   - pods/portforward
   verbs:
-  # create the krelay-server pod and forward local port to it
   - create
-  # watch the krelay-server pod
-  - watch
-  # clean the krelay-server pod
-  - delete
 
 # The following permissions is only requried if you want to forward the local port to the respective objects.
 - apiGroups:

--- a/pkg/kube/flags.go
+++ b/pkg/kube/flags.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
@@ -17,6 +18,11 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/knight42/krelay/pkg/constants"
+)
+
+const (
+	ttlSecondsAfterFinished int32 = 10
+	jobBackoffLimit         int32 = 0
 )
 
 type Flags struct {
@@ -82,24 +88,25 @@ func (f *Flags) ToResourceBuilder() *resource.Builder {
 	return resource.NewBuilder(f.cf)
 }
 
-func (f *Flags) buildServerPod() (*corev1.Pod, error) {
+func (f *Flags) buildServerJob() (*batchv1.Job, error) {
+	podLabels := map[string]string{
+		"app.kubernetes.io/name": constants.ServerName,
+		"app":                    constants.ServerName,
+	}
 	origPod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    metav1.NamespaceDefault,
-			GenerateName: constants.ServerName + "-",
-			Labels: map[string]string{
-				"app.kubernetes.io/name": constants.ServerName,
-				"app":                    constants.ServerName,
-			},
+			Namespace: metav1.NamespaceDefault,
+			Labels:    podLabels,
 			Annotations: map[string]string{
 				"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
 			},
 		},
 		Spec: corev1.PodSpec{
-			AutomountServiceAccountToken: toPtr(false),
-			EnableServiceLinks:           toPtr(false),
+			RestartPolicy:                corev1.RestartPolicyNever,
+			AutomountServiceAccountToken: new(false),
+			EnableServiceLinks:           new(false),
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: toPtr(true),
+				RunAsNonRoot: new(true),
 			},
 			Containers: []corev1.Container{
 				{
@@ -107,8 +114,8 @@ func (f *Flags) buildServerPod() (*corev1.Pod, error) {
 					Image:           f.serverImage,
 					ImagePullPolicy: corev1.PullAlways,
 					SecurityContext: &corev1.SecurityContext{
-						ReadOnlyRootFilesystem:   toPtr(true),
-						AllowPrivilegeEscalation: toPtr(false),
+						ReadOnlyRootFilesystem:   new(true),
+						AllowPrivilegeEscalation: new(false),
 					},
 				},
 			},
@@ -126,30 +133,47 @@ func (f *Flags) buildServerPod() (*corev1.Pod, error) {
 			},
 		},
 	}
-	if len(f.patch) == 0 && len(f.patchFile) == 0 {
-		return &origPod, nil
-	}
 
-	var patchBytes []byte
-	if len(f.patch) > 0 {
-		patchBytes = []byte(f.patch)
-	} else if len(f.patchFile) > 0 {
-		var err error
-		patchBytes, err = os.ReadFile(f.patchFile)
-		if err != nil {
-			return nil, fmt.Errorf("read file: %w", err)
+	if len(f.patch) > 0 || len(f.patchFile) > 0 {
+		var patchBytes []byte
+		if len(f.patch) > 0 {
+			patchBytes = []byte(f.patch)
+		} else {
+			var err error
+			patchBytes, err = os.ReadFile(f.patchFile)
+			if err != nil {
+				return nil, fmt.Errorf("read file: %w", err)
+			}
 		}
+		patched, err := patchPod(patchBytes, origPod)
+		if err != nil {
+			return nil, fmt.Errorf("patch server pod: %w", err)
+		}
+		origPod = *patched
 	}
 
-	patched, err := patchPod(patchBytes, origPod)
-	if err != nil {
-		return nil, fmt.Errorf("patch server pod: %w", err)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    origPod.Namespace,
+			GenerateName: constants.ServerName + "-",
+			Labels:       podLabels,
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            new(jobBackoffLimit),
+			TTLSecondsAfterFinished: new(ttlSecondsAfterFinished),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      origPod.Labels,
+					Annotations: origPod.Annotations,
+				},
+				Spec: origPod.Spec,
+			},
+		},
 	}
-
-	return patched, nil
+	return job, nil
 }
 
-func (f *Flags) RunServerPod(ctx context.Context) (*ServerPod, error) {
+func (f *Flags) RunServerJob(ctx context.Context) (*ServerJob, error) {
 	restCfg, err := f.ToRESTConfig()
 	if err != nil {
 		return nil, err
@@ -159,23 +183,23 @@ func (f *Flags) RunServerPod(ctx context.Context) (*ServerPod, error) {
 		return nil, err
 	}
 
-	svrPod, err := f.buildServerPod()
+	svrJob, err := f.buildServerJob()
 	if err != nil {
 		return nil, err
 	}
 
-	l := slog.With(slog.String("namespace", svrPod.Namespace))
-	l.Info("Creating krelay-server")
-	createdPod, err := cs.CoreV1().Pods(svrPod.Namespace).Create(ctx, svrPod, metav1.CreateOptions{})
+	l := slog.With(slog.String("namespace", svrJob.Namespace))
+	l.Info("Creating krelay-server job")
+	createdJob, err := cs.BatchV1().Jobs(svrJob.Namespace).Create(ctx, svrJob, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("create krelay-server pod: %w", err)
+		return nil, fmt.Errorf("create krelay-server job: %w", err)
 	}
 
-	err = ensureServerPodIsRunning(ctx, cs, createdPod.Namespace, createdPod.Name)
+	podName, err := waitForServerJobPod(ctx, cs, createdJob.Namespace, createdJob.Name)
 	if err != nil {
-		return nil, fmt.Errorf("ensure krelay-server is running: %w", err)
+		return nil, fmt.Errorf("wait for krelay-server pod: %w", err)
 	}
-	l.Info("krelay-server is running", slog.String("pod", createdPod.Name))
+	l.Info("krelay-server is running", slog.String("job", createdJob.Name), slog.String("pod", podName))
 
 	restClient, err := rest.RESTClientFor(restCfg)
 	if err != nil {
@@ -184,7 +208,7 @@ func (f *Flags) RunServerPod(ctx context.Context) (*ServerPod, error) {
 
 	req := restClient.Post().
 		Resource("pods").
-		Namespace(svrPod.Namespace).Name(createdPod.Name).
+		Namespace(createdJob.Namespace).Name(podName).
 		SubResource("portforward")
 
 	dialer, err := createDialer(restCfg, req.URL())
@@ -198,26 +222,25 @@ func (f *Flags) RunServerPod(ctx context.Context) (*ServerPod, error) {
 		return nil, fmt.Errorf("dial: %w", err)
 	}
 
-	ret := &ServerPod{
+	return &ServerJob{
 		cs:         cs,
-		pod:        createdPod,
+		job:        createdJob,
 		streamConn: streamConn,
-	}
-	return ret, nil
+	}, nil
 }
 
-type ServerPod struct {
+type ServerJob struct {
 	cs         kubernetes.Interface
-	pod        *corev1.Pod
+	job        *batchv1.Job
 	streamConn httpstream.Connection
 }
 
-func (p *ServerPod) StreamConn() httpstream.Connection {
+func (p *ServerJob) StreamConn() httpstream.Connection {
 	return p.streamConn
 }
 
-func (p *ServerPod) Close() error {
+func (p *ServerJob) Close() error {
 	_ = p.streamConn.Close()
-	removeServerPod(p.cs, p.pod.Namespace, p.pod.Name, time.Minute)
+	removeServerJob(p.cs, p.job.Namespace, p.job.Name, time.Minute)
 	return nil
 }

--- a/pkg/kube/flags.go
+++ b/pkg/kube/flags.go
@@ -194,15 +194,20 @@ func (f *Flags) RunServerJob(ctx context.Context) (*ServerJob, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create krelay-server job: %w", err)
 	}
+	// Clean up the Job if anything below fails — the caller never gets a
+	// ServerJob handle to call Close() on.
+	cleanup := func() { removeServerJob(cs, createdJob.Namespace, createdJob.Name, time.Minute) }
 
 	podName, err := waitForServerJobPod(ctx, cs, createdJob.Namespace, createdJob.Name)
 	if err != nil {
+		cleanup()
 		return nil, fmt.Errorf("wait for krelay-server pod: %w", err)
 	}
 	l.Info("krelay-server is running", slog.String("job", createdJob.Name), slog.String("pod", podName))
 
 	restClient, err := rest.RESTClientFor(restCfg)
 	if err != nil {
+		cleanup()
 		return nil, err
 	}
 
@@ -213,6 +218,7 @@ func (f *Flags) RunServerJob(ctx context.Context) (*ServerJob, error) {
 
 	dialer, err := createDialer(restCfg, req.URL())
 	if err != nil {
+		cleanup()
 		return nil, fmt.Errorf("create dialer: %w", err)
 	}
 

--- a/pkg/kube/flags.go
+++ b/pkg/kube/flags.go
@@ -225,6 +225,7 @@ func (f *Flags) RunServerJob(ctx context.Context) (*ServerJob, error) {
 	l.Info("Creating port-forward stream to krelay-server pod")
 	streamConn, _, err := dialer.Dial(constants.PortForwardProtocolV1Name)
 	if err != nil {
+		cleanup()
 		return nil, fmt.Errorf("dial: %w", err)
 	}
 

--- a/pkg/kube/flags.go
+++ b/pkg/kube/flags.go
@@ -52,7 +52,7 @@ func (f *Flags) AddFlags(flags *pflag.FlagSet) {
 
 	flags.StringVarP(&f.patch, "patch", "p", "", "The merge patch to be applied to the krelay-server pod.")
 	flags.StringVar(&f.patchFile, "patch-file", "", "A file containing a merge patch to be applied to the krelay-server pod.")
-	flags.StringVar(&f.serverImage, "server.image", "ghcr.io/knight42/krelay-server:v0.0.4", "The krelay-server image to use.")
+	flags.StringVar(&f.serverImage, "server.image", "ghcr.io/knight42/krelay-server:v0.0.5", "The krelay-server image to use.")
 }
 
 func (f *Flags) GetNamespace() (string, bool, error) {

--- a/pkg/kube/utils.go
+++ b/pkg/kube/utils.go
@@ -28,10 +28,6 @@ import (
 	slogutil "github.com/knight42/krelay/pkg/slog"
 )
 
-func toPtr[T any](v T) *T {
-	return &v
-}
-
 func patchPod(patchBytes []byte, origPod corev1.Pod) (*corev1.Pod, error) {
 	patchJSONBytes, err := yaml.ToJSON(patchBytes)
 	if err != nil {
@@ -57,25 +53,24 @@ func patchPod(patchBytes []byte, origPod corev1.Pod) (*corev1.Pod, error) {
 	return &patchedPod, nil
 }
 
-func ensureServerPodIsRunning(ctx context.Context, cs kubernetes.Interface, namespace, podName string) error {
+// waitForServerJobPod blocks until a pod owned by the given Job enters the
+// Running state, then returns its name so the caller can open a port-forward
+// stream to it.
+func waitForServerJobPod(ctx context.Context, cs kubernetes.Interface, namespace, jobName string) (string, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
 
 	w, err := cs.CoreV1().Pods(namespace).Watch(timeoutCtx, metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("metadata.name=%s", podName),
+		LabelSelector: fmt.Sprintf("job-name=%s", jobName),
 	})
 	if err != nil {
-		return fmt.Errorf("watch krelay-server pod: %w", err)
+		return "", fmt.Errorf("watch krelay-server pod: %w", err)
 	}
 	defer w.Stop()
 
-	running := false
-loop:
 	for ev := range w.ResultChan() {
 		switch ev.Type {
-		case watch.Deleted, watch.Error:
-			break loop
-		case watch.Modified, watch.Added:
+		case watch.Added, watch.Modified:
 		default:
 			continue
 		}
@@ -84,30 +79,27 @@ loop:
 		for _, status := range podObj.Status.ContainerStatuses {
 			// there is only one container in the pod
 			if status.State.Running != nil {
-				running = true
-				break loop
+				return podObj.Name, nil
 			}
-			slog.Debug("Pod is not running. Will retry.", slog.String("pod", podObj.Name))
 		}
+		slog.Debug("Pod is not running. Will retry.", slog.String("pod", podObj.Name))
 	}
-	if !running {
-		return fmt.Errorf("krelay-server pod is not running")
-	}
-
-	return nil
+	return "", fmt.Errorf("krelay-server pod is not running")
 }
 
-func removeServerPod(cs kubernetes.Interface, namespace, podName string, timeout time.Duration) {
-	l := slog.With(slog.String("pod", podName))
-	l.Info("Removing krelay-server pod")
+func removeServerJob(cs kubernetes.Interface, namespace, jobName string, timeout time.Duration) {
+	l := slog.With(slog.String("job", jobName))
+	l.Info("Removing krelay-server job")
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	err := cs.CoreV1().Pods(namespace).Delete(ctx, podName, metav1.DeleteOptions{
-		GracePeriodSeconds: toPtr[int64](0),
+	bg := metav1.DeletePropagationBackground
+	err := cs.BatchV1().Jobs(namespace).Delete(ctx, jobName, metav1.DeleteOptions{
+		GracePeriodSeconds: new(int64(0)),
+		PropagationPolicy:  &bg,
 	})
 	if err != nil && !k8serr.IsNotFound(err) {
-		l.Error("Fail to remove krelay-server pod", slogutil.Error(err))
+		l.Error("Fail to remove krelay-server job", slogutil.Error(err))
 	}
 }
 

--- a/pkg/kube/utils.go
+++ b/pkg/kube/utils.go
@@ -70,6 +70,10 @@ func waitForServerJobPod(ctx context.Context, cs kubernetes.Interface, namespace
 
 	for ev := range w.ResultChan() {
 		switch ev.Type {
+		case watch.Deleted:
+			return "", fmt.Errorf("krelay-server pod was deleted before becoming ready")
+		case watch.Error:
+			return "", fmt.Errorf("watch error for krelay-server pod: %v", ev.Object)
 		case watch.Added, watch.Modified:
 		default:
 			continue
@@ -84,7 +88,7 @@ func waitForServerJobPod(ctx context.Context, cs kubernetes.Interface, namespace
 		}
 		slog.Debug("Pod is not running. Will retry.", slog.String("pod", podObj.Name))
 	}
-	return "", fmt.Errorf("krelay-server pod is not running")
+	return "", fmt.Errorf("timed out waiting for krelay-server pod to be running")
 }
 
 func removeServerJob(cs kubernetes.Interface, namespace, jobName string, timeout time.Duration) {

--- a/pkg/xnet/proto.go
+++ b/pkg/xnet/proto.go
@@ -3,4 +3,5 @@ package xnet
 const (
 	ProtocolTCP byte = iota
 	ProtocolUDP
+	ProtocolKeepalive
 )

--- a/pkg/xnet/udp_test.go
+++ b/pkg/xnet/udp_test.go
@@ -27,9 +27,7 @@ func TestUDPConn(t *testing.T) {
 	defer serverConn.Close()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		svrUDPConn := &UDPConn{UDPConn: serverConn.(*net.UDPConn)}
 		buf := make([]byte, 10)
 		n, cliAddr, err := svrUDPConn.ReadFrom(buf)
@@ -49,7 +47,7 @@ func TestUDPConn(t *testing.T) {
 			t.Errorf("WriteTo: %v", err)
 			return
 		}
-	}()
+	})
 
 	clientConn, err := net.Dial("udp", serverConn.LocalAddr().String())
 	r.NoError(err)

--- a/test/e2e/framework_test.go
+++ b/test/e2e/framework_test.go
@@ -262,6 +262,10 @@ func waitForDeploymentReady(ctx context.Context, namespace, name string) error {
 }
 
 func serverPodPatch() string {
+	return serverPodPatchWithArgs()
+}
+
+func serverPodPatchWithArgs(serverArgs ...string) string {
 	patch := map[string]any{
 		"metadata": map[string]any{
 			"namespace": testNS,
@@ -269,6 +273,29 @@ func serverPodPatch() string {
 				"krelay-e2e-run-id": testRunID,
 			},
 		},
+	}
+	img := os.Getenv("KRELAY_SERVER_IMAGE")
+	if img != "" {
+		container := map[string]any{
+			"name":            "krelay-server",
+			"image":           img,
+			"imagePullPolicy": "IfNotPresent",
+		}
+		if len(serverArgs) > 0 {
+			container["args"] = serverArgs
+		}
+		patch["spec"] = map[string]any{
+			"containers": []any{container},
+		}
+	} else if len(serverArgs) > 0 {
+		patch["spec"] = map[string]any{
+			"containers": []any{
+				map[string]any{
+					"name": "krelay-server",
+					"args": serverArgs,
+				},
+			},
+		}
 	}
 	b, _ := json.Marshal(patch)
 	return string(b)
@@ -361,6 +388,79 @@ func startKrelay(t *testing.T, readyCount int, readyPattern string, args ...stri
 	return ki
 }
 
+// startKrelayWithServerArgs is like startKrelay but injects custom server
+// container args (e.g., --idle-timeout=15s) into the pod patch.
+func startKrelayWithServerArgs(t *testing.T, serverArgs []string, readyCount int, readyPattern string, args ...string) *krelayInstance {
+	t.Helper()
+
+	fullArgs := append([]string{}, args...)
+	if img := os.Getenv("KRELAY_SERVER_IMAGE"); img != "" {
+		fullArgs = append(fullArgs, "--server.image", img)
+	}
+	fullArgs = append(fullArgs, "--patch", serverPodPatchWithArgs(serverArgs...))
+
+	cmd := exec.Command(krelayBin, fullArgs...)
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	cmd.Stdout = w
+	cmd.Stderr = w
+
+	require.NoError(t, cmd.Start())
+	w.Close()
+
+	ki := &krelayInstance{t: t, cmd: cmd, done: make(chan struct{})}
+
+	go func() {
+		_ = cmd.Wait()
+		close(ki.done)
+	}()
+
+	ready := make(chan struct{})
+	matchCount := 0
+
+	go func() {
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			line := scanner.Text()
+			ki.mu.Lock()
+			ki.output = append(ki.output, line)
+			if strings.Contains(line, readyPattern) {
+				ki.readyLines = append(ki.readyLines, line)
+				matchCount++
+				if matchCount >= readyCount {
+					select {
+					case <-ready:
+					default:
+						close(ready)
+					}
+				}
+			}
+			ki.mu.Unlock()
+		}
+		r.Close()
+	}()
+
+	select {
+	case <-ready:
+		t.Log("krelay is ready")
+	case <-ki.done:
+		ki.mu.Lock()
+		out := strings.Join(ki.output, "\n")
+		ki.mu.Unlock()
+		t.Fatalf("krelay exited before becoming ready. Output:\n%s", out)
+	case <-time.After(3 * time.Minute):
+		ki.stop()
+		ki.mu.Lock()
+		out := strings.Join(ki.output, "\n")
+		ki.mu.Unlock()
+		t.Fatalf("krelay did not become ready within 3 minutes. Output:\n%s", out)
+	}
+
+	t.Cleanup(ki.stop)
+	return ki
+}
+
 func (ki *krelayInstance) stop() {
 	ki.mu.Lock()
 	if ki.stopped {
@@ -377,6 +477,19 @@ func (ki *krelayInstance) stop() {
 		_ = ki.cmd.Process.Kill()
 		<-ki.done
 	}
+}
+
+func (ki *krelayInstance) kill() {
+	ki.mu.Lock()
+	if ki.stopped {
+		ki.mu.Unlock()
+		return
+	}
+	ki.stopped = true
+	ki.mu.Unlock()
+
+	_ = ki.cmd.Process.Kill()
+	<-ki.done
 }
 
 func (ki *krelayInstance) dumpOutput() string {
@@ -400,6 +513,39 @@ func (ki *krelayInstance) localPorts(t *testing.T) []int {
 	}
 	require.NotEmpty(t, ports, "no local ports found in krelay output")
 	return ports
+}
+
+// listKrelayJobs returns all krelay-server Jobs in the test namespace.
+func listKrelayJobs(t *testing.T) []string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	jobs, err := kubeClient.BatchV1().Jobs(testNS).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=krelay-server",
+	})
+	require.NoError(t, err)
+	var names []string
+	for _, j := range jobs.Items {
+		names = append(names, j.Name)
+	}
+	return names
+}
+
+// waitForNoKrelayJobs polls until no krelay-server Jobs remain in the test namespace.
+func waitForNoKrelayJobs(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		names := listKrelayJobs(t)
+		if len(names) == 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("krelay-server jobs still present after %s: %v", timeout, names)
+		case <-time.After(2 * time.Second):
+		}
+	}
 }
 
 // httpGetOK performs an HTTP GET and asserts a 200 response.

--- a/test/e2e/job_lifecycle_test.go
+++ b/test/e2e/job_lifecycle_test.go
@@ -1,0 +1,69 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobCreatedNotPod(t *testing.T) {
+	ki := startKrelay(t, 1, "Forwarding", "-n", testNS, "svc/test-nginx-svc", ":80")
+
+	jobs := listKrelayJobs(t)
+	require.NotEmpty(t, jobs, "expected a krelay-server Job in namespace %s", testNS)
+	t.Logf("krelay-server Job(s): %v", jobs)
+
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ki.localPorts(t)[0]))
+}
+
+func TestJobCleanedUpOnSIGINT(t *testing.T) {
+	ki := startKrelay(t, 1, "Forwarding", "-n", testNS, "svc/test-nginx-svc", ":80")
+
+	jobs := listKrelayJobs(t)
+	require.NotEmpty(t, jobs)
+
+	ki.stop()
+	waitForNoKrelayJobs(t, 30*time.Second)
+}
+
+func TestIdleTimeoutExitsAfterClientKilled(t *testing.T) {
+	ki := startKrelayWithServerArgs(t,
+		[]string{"--idle-timeout=15s"},
+		1, "Forwarding",
+		"-n", testNS, "svc/test-nginx-svc", ":80",
+	)
+
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ki.localPorts(t)[0]))
+
+	jobs := listKrelayJobs(t)
+	require.NotEmpty(t, jobs, "expected krelay-server Job before kill")
+
+	ki.kill()
+
+	// Server should idle-timeout (15s) + TTL GC (10s) = ~25s.
+	// Give generous margin.
+	waitForNoKrelayJobs(t, 60*time.Second)
+}
+
+func TestHeartbeatKeepsServerAlive(t *testing.T) {
+	ki := startKrelayWithServerArgs(t,
+		[]string{"--idle-timeout=10s"},
+		1, "Forwarding",
+		"-n", testNS, "svc/test-nginx-svc", ":80",
+	)
+
+	// Wait longer than the idle timeout while client is alive
+	// (heartbeats should prevent server exit).
+	time.Sleep(20 * time.Second)
+
+	jobs := listKrelayJobs(t)
+	assert.NotEmpty(t, jobs, "server should still be alive — heartbeat should prevent idle exit")
+
+	// Verify forwarding still works
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ki.localPorts(t)[0]))
+}


### PR DESCRIPTION
## Summary

Replace the krelay-server's bare Pod with a `batch/v1.Job` and add a client-side heartbeat so the server can detect when the port-forward tunnel drops and self-exit. Together these ensure orphaned server instances get cleaned up when the client crashes.

### Server (`cmd/server/main.go`)
- New `--idle-timeout` flag (default `5m`, `0` disables).
- `idleTracker` tracks `activeConns` and `lastActivity` with atomics. Background monitor ticks every `max(timeout/4, 1s)`; shuts down when `activeConns == 0 && idle >= timeout`.
- `ProtocolKeepalive` case in `handleConn`: returns immediately (no dial, no ACK).
- `onDisconnect` updates `lastActivity` before decrementing `activeConns` to prevent a race where the monitor sees zero connections with a stale timestamp.

### Client (`cmd/client/*.go`)
- `sendHeartbeats(conn, interval)`: goroutine sends a `ProtocolKeepalive` stream every 5s. Logs and exits on createStream or write failure. Drains `errCh` to avoid goroutine leaks.
- `RunServerJob` replaces `RunServerPod`. Builds a `batch/v1.Job` (`backoffLimit=0`, `ttlSecondsAfterFinished=10`, `restartPolicy=Never`). Watches pods by `job-name` label. Explicit `cleanup()` on every error path after Job creation.
- `waitForServerJobPod` handles `watch.Deleted` / `watch.Error` explicitly; distinguishes timeout from pod failure in error messages.
- `Close()` deletes the Job with `PropagationPolicy=Background`.

### RBAC (`manifests/rbac.yaml`)
- Drop `pods: create/delete` (Job controller handles pod lifecycle).
- Add `batch/jobs: create, delete`.
- Keep `pods: watch` + `pods/portforward: create`.
- Fix pre-existing typo: "requried" → "required".

### Misc
- Bump `go.mod` to `go 1.26.0`, `manifests/Dockerfile-server` to `golang:1.26`.
- Replace `toPtr[T any]` helper with Go 1.26's `new(value)` builtin.
- Adopt `sync.WaitGroup.Go` in `pkg/xnet/udp_test.go`; enable `modernize` linter.
- Bump default `--server.image` to `v0.0.5`.
- Add `ProtocolKeepalive=2` to wire protocol docs in `ARCHITECTURE.md`.
- Update `CLAUDE.md` Go version to 1.26.

## Compatibility notes

- **Old server + new client**: heartbeats hit `AckCodeUnknownProtocol` (client never reads it — harmless). Idle-timeout won't exist on the old server, so a client crash leaves the Job running until TTL expires after the server's process exits for other reasons. Normal graceful exit still works.
- **RBAC**: users with custom RBAC bindings need `batch/jobs: create, delete` before upgrading.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` (0 issues)
- [x] Unit tests for `sendHeartbeats` (4 cases: CloseChan, periodic send, createStream error, write error)
- [x] E2e: `TestJobCreatedNotPod` — Job created, not bare Pod
- [x] E2e: `TestJobCleanedUpOnSIGINT` — SIGINT deletes Job
- [x] E2e: `TestIdleTimeoutExitsAfterClientKilled` — SIGKILL → idle exit → TTL GC
- [x] E2e: `TestHeartbeatKeepsServerAlive` — heartbeats prevent exit with idle-timeout=10s, client alive 20s
- [x] E2e: all 13 tests pass on OrbStack k8s v1.33.5 (arm64)
- [x] Manual: `--patch` with `metadata.namespace` retargets Job to patched namespace
- [x] Manual: bad image → SIGINT → `cleanup()` deletes orphaned Job

🤖 Generated with [Claude Code](https://claude.com/claude-code)