### PR TITLE
Add e2e tests and fix broken cobra flag registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `make test` — `go test -race -v ./...`. Single test: `go test -race -run TestName ./pkg/xnet/...`.
 - `make lint` — `golangci-lint run`.
 - `make server-image` — build `ghcr.io/knight42/krelay-server` from `manifests/Dockerfile-server`.
+- `make test-e2e` — run e2e tests against a live k8s cluster (`go test -tags e2e ./test/e2e/`). Set `KRELAY_SERVER_IMAGE` to override the server image.
 
 Go 1.25. Release via GoReleaser + Krew (`.goreleaser.yaml`, `.krew.yaml`).
 
@@ -22,7 +23,12 @@ Two binaries cooperate over a single Kubernetes port-forward stream: **client** 
 - Port parsing: `pkg/ports`
 - Server-pod lifecycle and SPDY/websocket dialer: `pkg/kube`
 
+## Testing policy
+
+Every new user-facing feature must include corresponding e2e tests in `test/e2e/`. E2e tests use the `//go:build e2e` tag so `make test` skips them. Each test must be independent (no ordering dependencies), start its own krelay process, and clean up after itself.
+
 ## Gotchas
 
 - `pkg/slog/` is exempt from `revive` var-naming (`.golangci.yaml`).
 - SPDY-over-websocket is tried first; set `KUBECTL_PORT_FORWARD_WEBSOCKETS=false` to force plain SPDY.
+- Register cobra flags with `cmd.Flags()`, not `cmd.LocalFlags()`. `LocalFlags()` returns a computed set that doesn't participate in parsing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `make test` — `go test -race -v ./...`. Single test: `go test -race -run TestName ./pkg/xnet/...`.
 - `make lint` — `golangci-lint run`.
 - `make server-image` — build `ghcr.io/knight42/krelay-server` from `manifests/Dockerfile-server`.
-- `make test-e2e` — run e2e tests against a live k8s cluster (`go test -tags e2e ./test/e2e/`). Set `KRELAY_SERVER_IMAGE` to override the server image.
+- `make test-e2e` — run e2e tests against a live k8s cluster (`go test -count=1 -tags e2e ./test/e2e/`). Set `KRELAY_SERVER_IMAGE` to override the server image.
 
 Go 1.25. Release via GoReleaser + Krew (`.goreleaser.yaml`, `.krew.yaml`).
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ lint:
 test:
 	go test -race -v ./...
 
+.PHONY: test-e2e
+test-e2e:
+	go test -tags e2e -v -timeout 15m ./test/e2e/
+
 .PHONY: coverage
 coverage:
 	go test -race -v -coverprofile=cover.out ./...

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test:
 
 .PHONY: test-e2e
 test-e2e:
-	go test -tags e2e -v -timeout 15m ./test/e2e/
+	go test -count=1 -tags e2e -v -timeout 15m ./test/e2e/
 
 .PHONY: coverage
 coverage:

--- a/cmd/client/command_proxy.go
+++ b/cmd/client/command_proxy.go
@@ -183,7 +183,7 @@ func newProxyCommand(kf *kube.Flags) *cobra.Command {
 			return o.Run(ctx, args)
 		},
 	}
-	flags := cmd.LocalFlags()
+	flags := cmd.Flags()
 
 	flags.StringVarP(&o.listenAddr, "listen", "l", "127.0.0.1:1080", "SOCKS5 proxy listen address")
 	return cmd

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -208,7 +208,7 @@ This behavior can be disabled by setting the environment variable "KUBECTL_PORT_
 	kf.AddFlags(c.PersistentFlags())
 
 	c.Flags().SortFlags = false
-	flags := c.LocalFlags()
+	flags := c.Flags()
 	flags.BoolVarP(&printVersion, "version", "V", false, "Print version info and exit.")
 	flags.StringVarP(&o.address, "address", "l", "127.0.0.1", "Address to listen on. Only accepts IP addresses as a value.")
 	flags.StringVarP(&o.targetsFile, "file", "f", "", "Forward to the targets specified in the given file, with one target per line.")

--- a/test/e2e/framework_test.go
+++ b/test/e2e/framework_test.go
@@ -5,12 +5,14 @@ package e2e
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -37,9 +39,6 @@ func TestMain(m *testing.M) {
 	var code int
 	defer func() { os.Exit(code) }()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
 	repoRoot, err := findRepoRoot()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "find repo root: %v\n", err)
@@ -55,9 +54,11 @@ func TestMain(m *testing.M) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	krelayBin = filepath.Join(tmpDir, "krelay")
 	fmt.Println("Building krelay binary...")
-	buildCmd := exec.CommandContext(ctx, "go", "build", "-o", krelayBin, "./cmd/client")
+	krelayBin = filepath.Join(tmpDir, "krelay")
+	buildCtx, buildCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer buildCancel()
+	buildCmd := exec.CommandContext(buildCtx, "go", "build", "-o", krelayBin, "./cmd/client")
 	buildCmd.Dir = repoRoot
 	buildCmd.Stdout = os.Stdout
 	buildCmd.Stderr = os.Stderr
@@ -67,6 +68,9 @@ func TestMain(m *testing.M) {
 		return
 	}
 
+	clusterCtx, clusterCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer clusterCancel()
+
 	kubeClient, err = buildKubeClient()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "create k8s client: %v\n", err)
@@ -74,10 +78,12 @@ func TestMain(m *testing.M) {
 		return
 	}
 
+	cleanupStaleNamespaces(clusterCtx)
+
 	testRunID = fmt.Sprintf("%x", time.Now().UnixNano())
 	testNS = fmt.Sprintf("krelay-e2e-%s", testRunID)
 	fmt.Printf("Creating test namespace %s...\n", testNS)
-	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+	_, err = kubeClient.CoreV1().Namespaces().Create(clusterCtx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: testNS},
 	}, metav1.CreateOptions{})
 	if err != nil {
@@ -86,14 +92,12 @@ func TestMain(m *testing.M) {
 		return
 	}
 	defer func() {
-		cleanupCtx := context.Background()
-		cleanupServerPods(cleanupCtx)
 		fmt.Printf("Deleting test namespace %s...\n", testNS)
-		_ = kubeClient.CoreV1().Namespaces().Delete(cleanupCtx, testNS, metav1.DeleteOptions{})
+		_ = kubeClient.CoreV1().Namespaces().Delete(context.Background(), testNS, metav1.DeleteOptions{})
 	}()
 
 	fmt.Println("Deploying test fixtures...")
-	if err := deployFixtures(ctx); err != nil {
+	if err := deployFixtures(clusterCtx); err != nil {
 		fmt.Fprintf(os.Stderr, "deploy fixtures: %v\n", err)
 		code = 1
 		return
@@ -259,39 +263,57 @@ func waitForDeploymentReady(ctx context.Context, namespace, name string) error {
 	}
 }
 
-func cleanupServerPods(ctx context.Context) {
-	pods, err := kubeClient.CoreV1().Pods(metav1.NamespaceDefault).List(ctx, metav1.ListOptions{
-		LabelSelector: "krelay-e2e-run-id=" + testRunID,
-	})
+func cleanupStaleNamespaces(ctx context.Context) {
+	nsList, err := kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "list krelay-server pods: %v\n", err)
 		return
 	}
-	for _, pod := range pods.Items {
-		fmt.Printf("Cleaning up leftover server pod %s...\n", pod.Name)
-		_ = kubeClient.CoreV1().Pods(metav1.NamespaceDefault).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+	cutoff := time.Now().Add(-30 * time.Minute)
+	for _, ns := range nsList.Items {
+		if strings.HasPrefix(ns.Name, "krelay-e2e-") && ns.CreationTimestamp.Time.Before(cutoff) {
+			fmt.Printf("Cleaning up stale namespace %s...\n", ns.Name)
+			_ = kubeClient.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
+		}
 	}
+}
+
+func serverPodPatch() string {
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"namespace": testNS,
+			"labels": map[string]string{
+				"krelay-e2e-run-id": testRunID,
+			},
+		},
+	}
+	b, _ := json.Marshal(patch)
+	return string(b)
 }
 
 // krelayInstance manages a running krelay process.
 type krelayInstance struct {
-	t       *testing.T
-	cmd     *exec.Cmd
-	mu      sync.Mutex
-	output  []string
-	stopped bool
+	t          *testing.T
+	cmd        *exec.Cmd
+	mu         sync.Mutex
+	output     []string
+	readyLines []string
+	done       chan struct{}
+	stopped    bool
 }
 
-// startKrelay launches a krelay process and waits until it logs the readyPattern.
-func startKrelay(t *testing.T, readyPattern string, args ...string) *krelayInstance {
+var portRe = regexp.MustCompile(`(?:localAddr|address)=\S+:(\d+)`)
+
+// startKrelay launches a krelay process and waits until readyCount occurrences
+// of readyPattern appear in its output. It fails immediately if the process
+// exits before becoming ready.
+func startKrelay(t *testing.T, readyCount int, readyPattern string, args ...string) *krelayInstance {
 	t.Helper()
 
 	fullArgs := append([]string{}, args...)
 	if img := os.Getenv("KRELAY_SERVER_IMAGE"); img != "" {
 		fullArgs = append(fullArgs, "--server.image", img)
 	}
-	fullArgs = append(fullArgs, "--patch",
-		fmt.Sprintf(`{"metadata":{"labels":{"krelay-e2e-run-id":"%s"}}}`, testRunID))
+	fullArgs = append(fullArgs, "--patch", serverPodPatch())
 
 	cmd := exec.Command(krelayBin, fullArgs...)
 
@@ -303,10 +325,15 @@ func startKrelay(t *testing.T, readyPattern string, args ...string) *krelayInsta
 	require.NoError(t, cmd.Start())
 	w.Close()
 
-	ki := &krelayInstance{t: t, cmd: cmd}
+	ki := &krelayInstance{t: t, cmd: cmd, done: make(chan struct{})}
+
+	go func() {
+		_ = cmd.Wait()
+		close(ki.done)
+	}()
 
 	ready := make(chan struct{})
-	var readyOnce sync.Once
+	matchCount := 0
 
 	go func() {
 		scanner := bufio.NewScanner(r)
@@ -314,10 +341,18 @@ func startKrelay(t *testing.T, readyPattern string, args ...string) *krelayInsta
 			line := scanner.Text()
 			ki.mu.Lock()
 			ki.output = append(ki.output, line)
-			ki.mu.Unlock()
 			if strings.Contains(line, readyPattern) {
-				readyOnce.Do(func() { close(ready) })
+				ki.readyLines = append(ki.readyLines, line)
+				matchCount++
+				if matchCount >= readyCount {
+					select {
+					case <-ready:
+					default:
+						close(ready)
+					}
+				}
 			}
+			ki.mu.Unlock()
 		}
 		r.Close()
 	}()
@@ -325,6 +360,11 @@ func startKrelay(t *testing.T, readyPattern string, args ...string) *krelayInsta
 	select {
 	case <-ready:
 		t.Log("krelay is ready")
+	case <-ki.done:
+		ki.mu.Lock()
+		out := strings.Join(ki.output, "\n")
+		ki.mu.Unlock()
+		t.Fatalf("krelay exited before becoming ready. Output:\n%s", out)
 	case <-time.After(3 * time.Minute):
 		ki.stop()
 		ki.mu.Lock()
@@ -347,13 +387,11 @@ func (ki *krelayInstance) stop() {
 	ki.mu.Unlock()
 
 	_ = ki.cmd.Process.Signal(os.Interrupt)
-	done := make(chan error, 1)
-	go func() { done <- ki.cmd.Wait() }()
 	select {
-	case <-done:
+	case <-ki.done:
 	case <-time.After(30 * time.Second):
 		_ = ki.cmd.Process.Kill()
-		<-done
+		<-ki.done
 	}
 }
 
@@ -363,14 +401,21 @@ func (ki *krelayInstance) dumpOutput() string {
 	return strings.Join(ki.output, "\n")
 }
 
-// freePort returns an available TCP port on localhost.
-func freePort(t *testing.T) int {
+// localPorts extracts the bound local ports from the readiness log lines.
+func (ki *krelayInstance) localPorts(t *testing.T) []int {
 	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	port := l.Addr().(*net.TCPAddr).Port
-	l.Close()
-	return port
+	ki.mu.Lock()
+	defer ki.mu.Unlock()
+	var ports []int
+	for _, line := range ki.readyLines {
+		m := portRe.FindStringSubmatch(line)
+		if m != nil {
+			p, _ := strconv.Atoi(m[1])
+			ports = append(ports, p)
+		}
+	}
+	require.NotEmpty(t, ports, "no local ports found in krelay output")
+	return ports
 }
 
 // httpGetOK performs an HTTP GET and asserts a 200 response.

--- a/test/e2e/framework_test.go
+++ b/test/e2e/framework_test.go
@@ -78,8 +78,6 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	cleanupStaleNamespaces(clusterCtx)
-
 	testRunID = fmt.Sprintf("%x", time.Now().UnixNano())
 	testNS = fmt.Sprintf("krelay-e2e-%s", testRunID)
 	fmt.Printf("Creating test namespace %s...\n", testNS)
@@ -259,20 +257,6 @@ func waitForDeploymentReady(ctx context.Context, namespace, name string) error {
 		case <-ctx.Done():
 			return fmt.Errorf("timeout waiting for deployment %s/%s to be ready", namespace, name)
 		case <-time.After(2 * time.Second):
-		}
-	}
-}
-
-func cleanupStaleNamespaces(ctx context.Context) {
-	nsList, err := kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return
-	}
-	cutoff := time.Now().Add(-30 * time.Minute)
-	for _, ns := range nsList.Items {
-		if strings.HasPrefix(ns.Name, "krelay-e2e-") && ns.CreationTimestamp.Time.Before(cutoff) {
-			fmt.Printf("Cleaning up stale namespace %s...\n", ns.Name)
-			_ = kubeClient.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
 		}
 	}
 }

--- a/test/e2e/framework_test.go
+++ b/test/e2e/framework_test.go
@@ -29,6 +29,7 @@ var (
 	krelayBin    string
 	kubeClient   kubernetes.Interface
 	testNS       string
+	testRunID    string
 	svcClusterIP string
 )
 
@@ -73,7 +74,8 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	testNS = fmt.Sprintf("krelay-e2e-%d", time.Now().UnixNano())
+	testRunID = fmt.Sprintf("%x", time.Now().UnixNano())
+	testNS = fmt.Sprintf("krelay-e2e-%s", testRunID)
 	fmt.Printf("Creating test namespace %s...\n", testNS)
 	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: testNS},
@@ -89,8 +91,6 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Deleting test namespace %s...\n", testNS)
 		_ = kubeClient.CoreV1().Namespaces().Delete(cleanupCtx, testNS, metav1.DeleteOptions{})
 	}()
-
-	cleanupServerPods(ctx)
 
 	fmt.Println("Deploying test fixtures...")
 	if err := deployFixtures(ctx); err != nil {
@@ -261,7 +261,7 @@ func waitForDeploymentReady(ctx context.Context, namespace, name string) error {
 
 func cleanupServerPods(ctx context.Context) {
 	pods, err := kubeClient.CoreV1().Pods(metav1.NamespaceDefault).List(ctx, metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=krelay-server",
+		LabelSelector: "krelay-e2e-run-id=" + testRunID,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "list krelay-server pods: %v\n", err)
@@ -290,6 +290,8 @@ func startKrelay(t *testing.T, readyPattern string, args ...string) *krelayInsta
 	if img := os.Getenv("KRELAY_SERVER_IMAGE"); img != "" {
 		fullArgs = append(fullArgs, "--server.image", img)
 	}
+	fullArgs = append(fullArgs, "--patch",
+		fmt.Sprintf(`{"metadata":{"labels":{"krelay-e2e-run-id":"%s"}}}`, testRunID))
 
 	cmd := exec.Command(krelayBin, fullArgs...)
 

--- a/test/e2e/framework_test.go
+++ b/test/e2e/framework_test.go
@@ -1,0 +1,390 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	krelayBin    string
+	kubeClient   kubernetes.Interface
+	testNS       string
+	svcClusterIP string
+)
+
+func TestMain(m *testing.M) {
+	var code int
+	defer func() { os.Exit(code) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "find repo root: %v\n", err)
+		code = 1
+		return
+	}
+
+	tmpDir, err := os.MkdirTemp("", "krelay-e2e-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create temp dir: %v\n", err)
+		code = 1
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+
+	krelayBin = filepath.Join(tmpDir, "krelay")
+	fmt.Println("Building krelay binary...")
+	buildCmd := exec.CommandContext(ctx, "go", "build", "-o", krelayBin, "./cmd/client")
+	buildCmd.Dir = repoRoot
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+	if err := buildCmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "build krelay: %v\n", err)
+		code = 1
+		return
+	}
+
+	kubeClient, err = buildKubeClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create k8s client: %v\n", err)
+		code = 1
+		return
+	}
+
+	testNS = fmt.Sprintf("krelay-e2e-%d", time.Now().UnixNano())
+	fmt.Printf("Creating test namespace %s...\n", testNS)
+	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: testNS},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create namespace: %v\n", err)
+		code = 1
+		return
+	}
+	defer func() {
+		cleanupCtx := context.Background()
+		cleanupServerPods(cleanupCtx)
+		fmt.Printf("Deleting test namespace %s...\n", testNS)
+		_ = kubeClient.CoreV1().Namespaces().Delete(cleanupCtx, testNS, metav1.DeleteOptions{})
+	}()
+
+	cleanupServerPods(ctx)
+
+	fmt.Println("Deploying test fixtures...")
+	if err := deployFixtures(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "deploy fixtures: %v\n", err)
+		code = 1
+		return
+	}
+
+	fmt.Println("Running tests...")
+	code = m.Run()
+}
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found")
+		}
+		dir = parent
+	}
+}
+
+func buildKubeClient() (kubernetes.Interface, error) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		home, _ := os.UserHomeDir()
+		kubeconfig = filepath.Join(home, ".kube", "config")
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+func nginxPodSpec() corev1.PodSpec {
+	return corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "nginx",
+				Image: "nginx:alpine",
+				Ports: []corev1.ContainerPort{
+					{ContainerPort: 80, Protocol: corev1.ProtocolTCP},
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/",
+							Port: intstr.FromInt32(80),
+						},
+					},
+					PeriodSeconds: 2,
+				},
+			},
+		},
+	}
+}
+
+func deployFixtures(ctx context.Context) error {
+	deployLabels := map[string]string{"app": "test-nginx-deploy"}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-nginx-pod",
+			Namespace: testNS,
+			Labels:    map[string]string{"app": "test-nginx-pod"},
+		},
+		Spec: nginxPodSpec(),
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-nginx-svc",
+			Namespace: testNS,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: deployLabels,
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: 80, TargetPort: intstr.FromInt32(80), Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+
+	replicas := int32(1)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-nginx-deploy",
+			Namespace: testNS,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: deployLabels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: deployLabels},
+				Spec:       nginxPodSpec(),
+			},
+		},
+	}
+
+	if _, err := kubeClient.CoreV1().Pods(testNS).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create pod: %w", err)
+	}
+	if _, err := kubeClient.CoreV1().Services(testNS).Create(ctx, svc, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create service: %w", err)
+	}
+	if _, err := kubeClient.AppsV1().Deployments(testNS).Create(ctx, deploy, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create deployment: %w", err)
+	}
+
+	if err := waitForPodReady(ctx, testNS, "test-nginx-pod"); err != nil {
+		return fmt.Errorf("wait for pod ready: %w", err)
+	}
+	if err := waitForDeploymentReady(ctx, testNS, "test-nginx-deploy"); err != nil {
+		return fmt.Errorf("wait for deployment ready: %w", err)
+	}
+
+	createdSvc, err := kubeClient.CoreV1().Services(testNS).Get(ctx, "test-nginx-svc", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get service: %w", err)
+	}
+	svcClusterIP = createdSvc.Spec.ClusterIP
+	fmt.Printf("Fixtures ready. Service ClusterIP: %s\n", svcClusterIP)
+	return nil
+}
+
+func waitForPodReady(ctx context.Context, namespace, name string) error {
+	for {
+		pod, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for pod %s/%s to be ready", namespace, name)
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func waitForDeploymentReady(ctx context.Context, namespace, name string) error {
+	for {
+		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if deploy.Status.ReadyReplicas >= 1 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for deployment %s/%s to be ready", namespace, name)
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func cleanupServerPods(ctx context.Context) {
+	pods, err := kubeClient.CoreV1().Pods(metav1.NamespaceDefault).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=krelay-server",
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "list krelay-server pods: %v\n", err)
+		return
+	}
+	for _, pod := range pods.Items {
+		fmt.Printf("Cleaning up leftover server pod %s...\n", pod.Name)
+		_ = kubeClient.CoreV1().Pods(metav1.NamespaceDefault).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+	}
+}
+
+// krelayInstance manages a running krelay process.
+type krelayInstance struct {
+	t       *testing.T
+	cmd     *exec.Cmd
+	mu      sync.Mutex
+	output  []string
+	stopped bool
+}
+
+// startKrelay launches a krelay process and waits until it logs the readyPattern.
+func startKrelay(t *testing.T, readyPattern string, args ...string) *krelayInstance {
+	t.Helper()
+
+	fullArgs := append([]string{}, args...)
+	if img := os.Getenv("KRELAY_SERVER_IMAGE"); img != "" {
+		fullArgs = append(fullArgs, "--server.image", img)
+	}
+
+	cmd := exec.Command(krelayBin, fullArgs...)
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	cmd.Stdout = w
+	cmd.Stderr = w
+
+	require.NoError(t, cmd.Start())
+	w.Close()
+
+	ki := &krelayInstance{t: t, cmd: cmd}
+
+	ready := make(chan struct{})
+	var readyOnce sync.Once
+
+	go func() {
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			line := scanner.Text()
+			ki.mu.Lock()
+			ki.output = append(ki.output, line)
+			ki.mu.Unlock()
+			if strings.Contains(line, readyPattern) {
+				readyOnce.Do(func() { close(ready) })
+			}
+		}
+		r.Close()
+	}()
+
+	select {
+	case <-ready:
+		t.Log("krelay is ready")
+	case <-time.After(3 * time.Minute):
+		ki.stop()
+		ki.mu.Lock()
+		out := strings.Join(ki.output, "\n")
+		ki.mu.Unlock()
+		t.Fatalf("krelay did not become ready within 3 minutes. Output:\n%s", out)
+	}
+
+	t.Cleanup(ki.stop)
+	return ki
+}
+
+func (ki *krelayInstance) stop() {
+	ki.mu.Lock()
+	if ki.stopped {
+		ki.mu.Unlock()
+		return
+	}
+	ki.stopped = true
+	ki.mu.Unlock()
+
+	_ = ki.cmd.Process.Signal(os.Interrupt)
+	done := make(chan error, 1)
+	go func() { done <- ki.cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		_ = ki.cmd.Process.Kill()
+		<-done
+	}
+}
+
+func (ki *krelayInstance) dumpOutput() string {
+	ki.mu.Lock()
+	defer ki.mu.Unlock()
+	return strings.Join(ki.output, "\n")
+}
+
+// freePort returns an available TCP port on localhost.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port
+}
+
+// httpGetOK performs an HTTP GET and asserts a 200 response.
+func httpGetOK(t *testing.T, url string) {
+	t.Helper()
+	client := &http.Client{Timeout: 10 * time.Second}
+	var resp *http.Response
+	var err error
+	for range 10 {
+		resp, err = client.Get(url)
+		if err == nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.NoError(t, err, "HTTP GET %s failed", url)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status from %s", url)
+}

--- a/test/e2e/hostip_test.go
+++ b/test/e2e/hostip_test.go
@@ -8,15 +8,12 @@ import (
 )
 
 func TestForwardToClusterIP(t *testing.T) {
-	port := freePort(t)
-	startKrelay(t, "Forwarding", fmt.Sprintf("ip/%s", svcClusterIP), fmt.Sprintf("%d:80", port))
-	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port))
+	ki := startKrelay(t, 1, "Forwarding", fmt.Sprintf("ip/%s", svcClusterIP), ":80")
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ki.localPorts(t)[0]))
 }
 
 func TestForwardToHostname(t *testing.T) {
-	port := freePort(t)
-	startKrelay(t, "Forwarding",
-		fmt.Sprintf("host/test-nginx-svc.%s.svc.cluster.local", testNS),
-		fmt.Sprintf("%d:80", port))
-	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port))
+	ki := startKrelay(t, 1, "Forwarding",
+		fmt.Sprintf("host/test-nginx-svc.%s.svc.cluster.local", testNS), ":80")
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ki.localPorts(t)[0]))
 }

--- a/test/e2e/hostip_test.go
+++ b/test/e2e/hostip_test.go
@@ -1,0 +1,22 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestForwardToClusterIP(t *testing.T) {
+	port := freePort(t)
+	startKrelay(t, "Forwarding", fmt.Sprintf("ip/%s", svcClusterIP), fmt.Sprintf("%d:80", port))
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port))
+}
+
+func TestForwardToHostname(t *testing.T) {
+	port := freePort(t)
+	startKrelay(t, "Forwarding",
+		fmt.Sprintf("host/test-nginx-svc.%s.svc.cluster.local", testNS),
+		fmt.Sprintf("%d:80", port))
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port))
+}

--- a/test/e2e/multiport_test.go
+++ b/test/e2e/multiport_test.go
@@ -1,0 +1,40 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiplePorts(t *testing.T) {
+	port1 := freePort(t)
+	port2 := freePort(t)
+	startKrelay(t, "Forwarding", "-n", testNS, "svc/test-nginx-svc",
+		fmt.Sprintf("%d:80", port1), fmt.Sprintf("%d:80", port2))
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port1))
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port2))
+}
+
+func TestMultiTargetFile(t *testing.T) {
+	port1 := freePort(t)
+	port2 := freePort(t)
+
+	content := fmt.Sprintf("-n %s pod/test-nginx-pod %d:80\n-n %s svc/test-nginx-svc %d:80\n",
+		testNS, port1, testNS, port2)
+
+	tmpFile, err := os.CreateTemp("", "krelay-targets-*.txt")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+
+	_, err = tmpFile.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	startKrelay(t, "Forwarding", "-f", tmpFile.Name())
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port1))
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port2))
+}

--- a/test/e2e/multiport_test.go
+++ b/test/e2e/multiport_test.go
@@ -11,20 +11,15 @@ import (
 )
 
 func TestMultiplePorts(t *testing.T) {
-	port1 := freePort(t)
-	port2 := freePort(t)
-	startKrelay(t, "Forwarding", "-n", testNS, "svc/test-nginx-svc",
-		fmt.Sprintf("%d:80", port1), fmt.Sprintf("%d:80", port2))
-	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port1))
-	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port2))
+	ki := startKrelay(t, 2, "Forwarding", "-n", testNS, "svc/test-nginx-svc", ":80", ":80")
+	ports := ki.localPorts(t)
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ports[0]))
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ports[1]))
 }
 
 func TestMultiTargetFile(t *testing.T) {
-	port1 := freePort(t)
-	port2 := freePort(t)
-
-	content := fmt.Sprintf("-n %s pod/test-nginx-pod %d:80\n-n %s svc/test-nginx-svc %d:80\n",
-		testNS, port1, testNS, port2)
+	content := fmt.Sprintf("-n %s pod/test-nginx-pod :80\n-n %s svc/test-nginx-svc :80\n",
+		testNS, testNS)
 
 	tmpFile, err := os.CreateTemp("", "krelay-targets-*.txt")
 	require.NoError(t, err)
@@ -34,7 +29,8 @@ func TestMultiTargetFile(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tmpFile.Close())
 
-	startKrelay(t, "Forwarding", "-f", tmpFile.Name())
-	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port1))
-	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port2))
+	ki := startKrelay(t, 2, "Forwarding", "-f", tmpFile.Name())
+	ports := ki.localPorts(t)
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ports[0]))
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ports[1]))
 }

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -1,0 +1,45 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/proxy"
+)
+
+func TestSOCKS5Proxy(t *testing.T) {
+	port := freePort(t)
+	startKrelay(t, "SOCKS5 server is running", "proxy", "--listen", fmt.Sprintf("127.0.0.1:%d", port))
+
+	dialer, err := proxy.SOCKS5("tcp", fmt.Sprintf("127.0.0.1:%d", port), nil, proxy.Direct)
+	require.NoError(t, err)
+
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return dialer.Dial(network, addr)
+			},
+		},
+	}
+
+	svcAddr := fmt.Sprintf("http://test-nginx-svc.%s.svc.cluster.local", testNS)
+	var resp *http.Response
+	for range 10 {
+		resp, err = httpClient.Get(svcAddr)
+		if err == nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestSOCKS5Proxy(t *testing.T) {
-	port := freePort(t)
-	startKrelay(t, "SOCKS5 server is running", "proxy", "--listen", fmt.Sprintf("127.0.0.1:%d", port))
+	ki := startKrelay(t, 1, "SOCKS5 server is running", "proxy", "--listen", "127.0.0.1:0")
+	port := ki.localPorts(t)[0]
 
 	dialer, err := proxy.SOCKS5("tcp", fmt.Sprintf("127.0.0.1:%d", port), nil, proxy.Direct)
 	require.NoError(t, err)

--- a/test/e2e/tcp_test.go
+++ b/test/e2e/tcp_test.go
@@ -1,0 +1,26 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTCPForwardPod(t *testing.T) {
+	port := freePort(t)
+	startKrelay(t, "Forwarding", "-n", testNS, "pod/test-nginx-pod", fmt.Sprintf("%d:80", port))
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port))
+}
+
+func TestTCPForwardService(t *testing.T) {
+	port := freePort(t)
+	startKrelay(t, "Forwarding", "-n", testNS, "svc/test-nginx-svc", fmt.Sprintf("%d:80", port))
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port))
+}
+
+func TestTCPForwardDeployment(t *testing.T) {
+	port := freePort(t)
+	startKrelay(t, "Forwarding", "-n", testNS, "deploy/test-nginx-deploy", fmt.Sprintf("%d:80", port))
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port))
+}

--- a/test/e2e/tcp_test.go
+++ b/test/e2e/tcp_test.go
@@ -8,19 +8,16 @@ import (
 )
 
 func TestTCPForwardPod(t *testing.T) {
-	port := freePort(t)
-	startKrelay(t, "Forwarding", "-n", testNS, "pod/test-nginx-pod", fmt.Sprintf("%d:80", port))
-	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port))
+	ki := startKrelay(t, 1, "Forwarding", "-n", testNS, "pod/test-nginx-pod", ":80")
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ki.localPorts(t)[0]))
 }
 
 func TestTCPForwardService(t *testing.T) {
-	port := freePort(t)
-	startKrelay(t, "Forwarding", "-n", testNS, "svc/test-nginx-svc", fmt.Sprintf("%d:80", port))
-	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port))
+	ki := startKrelay(t, 1, "Forwarding", "-n", testNS, "svc/test-nginx-svc", ":80")
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ki.localPorts(t)[0]))
 }
 
 func TestTCPForwardDeployment(t *testing.T) {
-	port := freePort(t)
-	startKrelay(t, "Forwarding", "-n", testNS, "deploy/test-nginx-deploy", fmt.Sprintf("%d:80", port))
-	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", port))
+	ki := startKrelay(t, 1, "Forwarding", "-n", testNS, "deploy/test-nginx-deploy", ":80")
+	httpGetOK(t, fmt.Sprintf("http://127.0.0.1:%d/", ki.localPorts(t)[0]))
 }

--- a/test/e2e/udp_test.go
+++ b/test/e2e/udp_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUDPForwardService(t *testing.T) {
+	port := freePort(t)
+	startKrelay(t, "Forwarding", "-n", "kube-system", "svc/kube-dns", fmt.Sprintf("%d:53@udp", port))
+
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return net.Dial("udp", fmt.Sprintf("127.0.0.1:%d", port))
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	addrs, err := r.LookupHost(ctx, "kubernetes.default.svc.cluster.local")
+	require.NoError(t, err)
+	require.NotEmpty(t, addrs)
+}

--- a/test/e2e/udp_test.go
+++ b/test/e2e/udp_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestUDPForwardService(t *testing.T) {
-	port := freePort(t)
-	startKrelay(t, "Forwarding", "-n", "kube-system", "svc/kube-dns", fmt.Sprintf("%d:53@udp", port))
+	ki := startKrelay(t, 1, "Forwarding", "-n", "kube-system", "svc/kube-dns", ":53@udp")
+	port := ki.localPorts(t)[0]
 
 	r := &net.Resolver{
 		PreferGo: true,


### PR DESCRIPTION
## Summary

- **Fix broken flag registration**: `c.LocalFlags()` → `c.Flags()` in `cmd/client/main.go` and `cmd/client/command_proxy.go`. Cobra's `LocalFlags()` returns a computed FlagSet that doesn't participate in parsing, so `-f`, `-l`, `-v`, `-V`, and `proxy --listen` were silently ignored at runtime despite appearing in `--help`.
- **Add 9 e2e tests** in `test/e2e/` covering all major forwarding modes, run against a live k8s cluster with `make test-e2e`:
  - TCP forwarding to pod, service, deployment
  - UDP forwarding (via kube-dns DNS query)
  - IP address and hostname forwarding
  - Multi-port and multi-target file (`-f`) forwarding
  - SOCKS5 proxy tunneling
- **Makefile**: add `test-e2e` target
- Tests are gated behind `//go:build e2e` so `make test` is unaffected
- Each test is fully independent (no ordering dependency), starts its own krelay process on a unique port, and cleans up server pods on completion

## Test plan

- [x] `make test` — all existing unit tests pass
- [x] `make test-e2e` — all 9 e2e tests pass (requires a local k8s cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)