### PR TITLE
chore(lint): exclude goconst in test files

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -36,6 +36,7 @@ linters:
         text: "var-naming"
       - linters:
           - errcheck
+          - goconst
         path: _test.go
     paths:
       - third_party$


### PR DESCRIPTION
The `lint` job started failing on every PR (e.g. #106) after golangci-lint `latest` resolved to v2.12.2, whose `goconst` linter now reports repeated string literals in `_test.go` files (7 issues in `cmd/client/utils_test.go` and `pkg/ports/parser_test.go`).

Repeated literals in table-driven tests are idiomatic, so exclude `goconst` in test files, following the existing `errcheck` exclusion.

Verified locally with golangci-lint v2.12.2: `golangci-lint run` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)